### PR TITLE
Updated 'Why vacate' content

### DIFF
--- a/content/why-vacate.js
+++ b/content/why-vacate.js
@@ -1,7 +1,7 @@
 const whyVacateContent = {
   heroBanner: {
     heading: "Why Vacate",
-    subheading: `The process of vacating a conviction in Washington is convoluted, but it’s needed to avoid barriers in employment, housing and education. \n\nFind out why it’s important to vacate your conviction and get resources to help you while you work your way to it.`,
+    subheading: `Vacating a conviction in Washington is complicated and intimidating but doing so opens opportunities in employment, housing, and education. \n\nExplore the benefits of vacating your conviction and get resources to help you along the way.`,
     imgsrc: "/illustrations/team-building.svg",
   },
   buttons: [
@@ -23,7 +23,7 @@ const whyVacateContent = {
       title: "Employment",
       sectionId: "employment",
       subtitle:
-        "Simply having a conviction does not prevent you from having a job, however, it can be more difficult depending on the type of job and the employer. It is important to not lose hope while facing challenges such as:",
+        "A conviction does not prevent you from having a job, but roadblocks can pop up depending on the job or the employer. It is important to not lose hope while facing challenges such as: ",
       cardItems: [
         {
           title: "Long periods of unemployment",
@@ -63,7 +63,7 @@ const whyVacateContent = {
       title: "Housing",
       sectionId: "housing",
       subtitle:
-        "There are many different barriers that can prevent people with convictions from fair access to housing. Each different type of housing comes with its own set of obstacles that you should take into consideration when looking for housing:",
+        "A background check is an obstacle for people with a conviction and it can prevent access to certain opportunities. Here are the main challenges background checks present to those seeking an education:",
       cardItems: [
         {
           title: "Public Housing Authorities",


### PR DESCRIPTION
# Ticket 3225 Update the content on the "Why Vacate" page

-   [Update the content on the "Why Vacate" page](https://airtable.com/appfJZShN8K4tcWHU/pagZc4gC1J3AGJCAG?OjYm8=b%3AeyI0emRmdyI6W1s2LFsicmVjQjJrN1pMczZOb215VlkiXV1dfQ&Mif7S=recZAUdl3bNO7nCVJ&detail=eyJwYWdlSWQiOiJwYWcwSmF6REhuQURDT3VQbyIsInJvd0lkIjoicmVjWmUxOGxZRWRrczlVNDcifQ)

### Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation or testing
-   [X] Other

### Description

 Update _Why Vacate_ page content JSON file to make tone of page less negative and more positive. Using content team's [recommended changes](https://docs.google.com/document/d/1mMYth9kswBpzxzo07c6LEEDczetjn8ulIjUPMxZxrB0/edit), phrases on the _Why Vacate_ page have been replaced. 

### Checklist:

-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (if applicable)
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
-   [ ] New and existing unit tests pass locally with my changes
-   [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand.
