### PR TITLE
add https: to meta urls, update og:url to /donate

### DIFF
--- a/components/SocialMetaLinks.jsx
+++ b/components/SocialMetaLinks.jsx
@@ -4,7 +4,7 @@ function SocialMetaLinks() {
   return (
     <>
       <meta property="og:url" content="https://www.clearviction.org/donate" />
-      <meta property="og:type" content="article" />
+      <meta property="og:type" content="website" />
       <meta
         property="og:title"
         content="Clearviction.org: A fresh start for people with Washington State Convictions"

--- a/components/SocialMetaLinks.jsx
+++ b/components/SocialMetaLinks.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 function SocialMetaLinks() {
   return (
     <>
-      <meta property="og:url" content="//www.clearviction.org/givingtuesday" />
+      <meta property="og:url" content="https://www.clearviction.org/donate" />
       <meta property="og:type" content="article" />
       <meta
         property="og:title"
@@ -16,7 +16,7 @@ function SocialMetaLinks() {
       <meta
         name="image"
         property="og:image"
-        content="//cvp-team-photos.s3.us-west-2.amazonaws.com/Calculator_Two+Color+2..svg"
+        content="https://cvp-team-photos.s3.us-west-2.amazonaws.com/Calculator_Two+Color+2..svg"
       />
 
       <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
### Ticket(s)

After looking at the meta tags a little bit more, maybe they were somehow working like this in the old repo and are not valid with next..? Anyways, I added `https:` to the start of all the urls, and I updated the `og:url` from `/givingtuesday` to `/donate`. After that maybe we can see if Tomas can test posting using the `staging.clearviction.org` url. Not sure if this is the fix but I have verified everything else on the entire repo is the correct icons and images.

It still doesn't make sense where the Open Seattle and Democracy Lab stuff is coming from though. We have their images in the repo, but the only place they are used is in the footer.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand.
