### PR TITLE
299-Link Spacing

### DIFF
--- a/components/AccordionBuilder.tsx
+++ b/components/AccordionBuilder.tsx
@@ -34,7 +34,7 @@ export default function InfoDropdown({
         <MuiMarkdown>{summary}</MuiMarkdown>
       </AccordionSummary>
       <AccordionDetails sx={{ backgroundColor: grey[50] }}>
-        <Box px={2}>
+        <Box px={2} sx={{ '& p': { my: 2 } }}>
           <MuiMarkdown>{details}</MuiMarkdown>
         </Box>
       </AccordionDetails>


### PR DESCRIPTION
### Ticket(s)

- _https://airtable.com/appfJZShN8K4tcWHU/pag0LSYKL2EkzxPkR?2tvjz=rec0iQeSDMiCBgfr7&detail=eyJwYWdlSWQiOiJwYWd2OGpFaFU0UmVDb05FcSIsInJvd0lkIjoicmVjczlaSTBUYldXTFUwOXIiLCJzaG93Q29tbWVudHMiOmZhbHNlfQ_

### Type of change

_Please delete any options that are not relevant_

- [x] Bug fix (non-breaking change which fixes an issue)


### Description

The spacing between links made it difficult to tell what is a link vs a line break


### Screenshots

Include relevant screenshots.

#### Before
![Screen Shot 2023-06-21 at 8 46 49 AM](https://github.com/clearviction-devs/clearviction-wa/assets/89257201/c087a4a2-2655-4ec2-a106-5667c36ab8c9)

#### After
![Screen Shot 2023-06-21 at 8 47 39 AM](https://github.com/clearviction-devs/clearviction-wa/assets/89257201/0b1c3150-6397-4424-851d-38dde90eae24)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand.
