### PR TITLE
Wrong word used on why vacate page

### DIFF
--- a/content/why-vacate.ts
+++ b/content/why-vacate.ts
@@ -74,7 +74,7 @@ const whyVacateContent: WhyVacateContent = {
       title: 'Housing',
       sectionId: 'housing',
       subtitle:
-        'A background check is an obstacle for people with a conviction and it can prevent access to certain opportunities. Here are the main challenges background checks present to those seeking an education:',
+        'A background check is an obstacle for people with a conviction and it can prevent access to certain opportunities. Here are the main challenges background checks present to those seeking housing:',
       cardItems: [
         {
           title: 'Public Housing Authorities',


### PR DESCRIPTION
### Ticket(s)

- _[[Issue ticket 340](https://airtable.com/appfJZShN8K4tcWHU/paghvE9diS74Z0Csc?c7fi2=recVlR2mpPtILo60Y)]_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

On the website, under "why vacate", under "housing", we state: "A background check is an obstacle for people with a conviction and it can prevent access to certain opportunities. Here are the main challenges background checks present to those seeking AN EDUCATION".
Changes "AN EDUCATION" to "HOUSING" since we mean to say housing since we share obstacles about housing. Screenshots are provided to demonstrate. 

### Screenshots

#### Before

![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/423cd80a-aa46-49c3-bea7-f586c9bd6ec4)

#### After

![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/08c6ef48-2ee8-47bf-8d6c-56eb8fa14adb)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] There are no new linting errors in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
