### PR TITLE
Adjust hero banner image size for small devices

### DIFF
--- a/components/layout/HeroBanner.tsx
+++ b/components/layout/HeroBanner.tsx
@@ -141,6 +141,7 @@ export default function HeroBanner({
                   width={513}
                   height={386}
                   alt=""
+                  style={{ maxWidth: '95vw' }}
                   useImageDimensions
                 />
               ) : (

--- a/components/layout/HeroBanner.tsx
+++ b/components/layout/HeroBanner.tsx
@@ -141,7 +141,7 @@ export default function HeroBanner({
                   width={513}
                   height={386}
                   alt=""
-                  style={{ maxWidth: '95vw' }}
+                  style={{ maxWidth: '100%' }}
                   useImageDimensions
                 />
               ) : (


### PR DESCRIPTION
### Ticket(s)

- _[[Task 5707](https://airtable.com/appfJZShN8K4tcWHU/pagxblGyhI5EJIA3v?HjEAY=rec9RVAAbJDCNB4E6)]_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

On website, using small devices, the HeroBanner break because it is to big, showing some white parts on right side of the page. Can be noticed at staging environment.

### Screenshots

#### Before
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/191cd72a-aabc-4641-a02c-1f4fec4c369b)

![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/c0fa7b84-1834-4d1f-b344-5a764170e441)

#### After
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/01319120-a0cb-428d-adb8-d7b3c9199c5c)

![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/106eaa3e-2e09-4401-9302-5859f026de7d)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no new linting errors in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
