### PR TITLE
Fix bug 345

### DIFF
--- a/components/functional/CalcStepper.tsx
+++ b/components/functional/CalcStepper.tsx
@@ -1,9 +1,12 @@
+import { useMediaQuery } from '@mui/material';
 import Box from '@mui/material/Box';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import Stepper from '@mui/material/Stepper';
 import * as React from 'react';
 import { useEffect } from 'react';
+
+import theme from '../../styles/themes/theme.tsx';
 
 const steps = [
   'your offense',
@@ -13,6 +16,8 @@ const steps = [
 
 export default function HorizontalLinearStepper() {
   const [activeStep, setActiveStep] = React.useState(0);
+
+  const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
 
   const handleNext = () => {
     const { pathname } = window.location;
@@ -44,9 +49,22 @@ export default function HorizontalLinearStepper() {
           const labelProps: {
             optional?: React.ReactNode;
           } = {};
-          return (
+
+          const isActiveStep = steps[activeStep] === label;
+
+          if (matchesXS) {
+            return (
+              <Step key={label} {...stepProps}>
+                <StepLabel {...labelProps}>
+                  {isActiveStep ? label : null}
+                </StepLabel>
+              </Step>
+            );
+          } return (
             <Step key={label} {...stepProps}>
-              <StepLabel {...labelProps}>{label}</StepLabel>
+              <StepLabel {...labelProps}>
+                {label}
+              </StepLabel>
             </Step>
           );
         })}


### PR DESCRIPTION
### Ticket(s)

- _[[Airtable ticket 6105](https://airtable.com/appfJZShN8K4tcWHU/pagxblGyhI5EJIA3v?HjEAY=recgZge2MTw3NhFZo)]_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

CalcStepper component on mobile screens was cut off because it was displaying the title off all 3 steps which was too much text, too long. I adjusted the stepper to check if active step matches the current step's label, and only then to display the title of the step section. I tried to duplicate as little as possibly without nesting ternaries or if statements inside the JSX, both of which aren't allowed.

Also, for some reason (thinking the rendering), the useMediaQuery does work on the calculator!

Fixes # 345

### Screenshots

Include relevant screenshots.

#### Please include a screenshot of the Figma design file

The Figma doesn't exactly match our current stepper, but I did just spend another hour trying to override styles on different parts of the stepper and it didn't work out very well, so that can be a next step task. 

#### Before
<img width="335" alt="Screenshot 2023-08-03 at 1 35 00 PM" src="https://github.com/clearviction-devs/clearviction-wa/assets/76261375/f0f2b6ba-7f10-4165-848b-ac16c5d9f66d">
<img width="330" alt="Screenshot 2023-08-03 at 1 35 03 PM" src="https://github.com/clearviction-devs/clearviction-wa/assets/76261375/5566fc01-35d9-4a44-8f7a-3c4fbe49c55d">

#### After
<img width="333" alt="Screenshot 2023-08-03 at 1 33 52 PM" src="https://github.com/clearviction-devs/clearviction-wa/assets/76261375/faee0ed2-7205-4ccb-8aa3-55824e6cf51c">

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
