### PR TITLE
fix: move viewport meta tag back to app

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import '../styles/global.css';
 
 import { CacheProvider, EmotionCache } from '@emotion/react';
 import { CssBaseline, ThemeProvider } from '@mui/material';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import TagManager from 'react-gtm-module';
@@ -45,6 +46,9 @@ function MyApp({
 
   return (
     <CacheProvider value={emotionCache}>
+      <Head>
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
+      </Head>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <Header />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -27,8 +27,6 @@ export default class MyDocument extends Document {
             property="og:image"
             content="https://cvp-team-photos.s3.us-west-2.amazonaws.com/Calculator_Two+Color+2..svg"
           />
-
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="theme-color" content="#000000" />
           <meta
             name="description"


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Updates the recently merged meta tag PR. There was one piece of meta (viewport) in `_app.tsx` which we moved to document to keep everything clean, but that is apparently not allowed with Next, so this puts it back.


### Checklist:


- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
