### PR TITLE
fix: props on share button component

### DIFF
--- a/pages/get-involved.tsx
+++ b/pages/get-involved.tsx
@@ -111,7 +111,11 @@ function Partner() {
               <Typography sx={{ my: 3 }} variant="body1">
                 {content.partnerPage.text[2]}
               </Typography>
-              <ShareButtons />
+              <ShareButtons
+                popup={false}
+                setShareLinkCopied={() => {}}
+                shareLinkCopied={false}
+              />
             </Grid>
           </Grid>
         </PaperSection>


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Adds the props to the original use of ShareButtons component, that were recently added with the extension of the component. This was causing a build error in AWS. 

### Screenshots
<img width="1500" alt="Screenshot 2023-08-10 at 6 10 48 PM" src="https://github.com/clearviction-devs/clearviction-wa/assets/76261375/63f91d86-fc9a-46dd-88c2-4c656acbf6b6">

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
