### PR TITLE
Nemo 6244/fix waystoparticipate grid

### DIFF
--- a/pages/get-involved.tsx
+++ b/pages/get-involved.tsx
@@ -132,7 +132,7 @@ export default function GetInvolvedPage() {
         metaContent="Join the Clearviction team and break down barriers for formerly incarcerated individuals by making it easier to vacate their criminal records in Washington State"
       />
 
-      <Box sx={{ bgcolor: '#2f3554', pb: '64px' }}>
+      <Box sx={{ bgcolor: '#2f3554', pb: '64px', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
         <HeroBanner
           header="Share your expertise with us"
           subheading="There are many ways to participate with the Clearviction team, and we appreciate all of them!"
@@ -146,7 +146,7 @@ export default function GetInvolvedPage() {
         <Grid
           container
           spacing={2}
-          sx={{ maxWidth: '1200px', m: 'auto', mt: -8 }}
+          sx={{ maxWidth: '1200px', mt: -8}}
         >
           {content.waysToParticipate.map((card) => (
             <Grid item xs={12} sm={12} md={4} key={card.id}>

--- a/pages/get-involved.tsx
+++ b/pages/get-involved.tsx
@@ -132,7 +132,10 @@ export default function GetInvolvedPage() {
         metaContent="Join the Clearviction team and break down barriers for formerly incarcerated individuals by making it easier to vacate their criminal records in Washington State"
       />
 
-      <Box sx={{ bgcolor: '#2f3554', pb: '64px', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Box sx={{
+        bgcolor: '#2f3554', pb: '64px', display: 'flex', flexDirection: 'column', alignItems: 'center',
+      }}
+      >
         <HeroBanner
           header="Share your expertise with us"
           subheading="There are many ways to participate with the Clearviction team, and we appreciate all of them!"
@@ -146,7 +149,7 @@ export default function GetInvolvedPage() {
         <Grid
           container
           spacing={2}
-          sx={{ maxWidth: '1200px', mt: -8}}
+          sx={{ maxWidth: '1200px', mt: -8 }}
         >
           {content.waysToParticipate.map((card) => (
             <Grid item xs={12} sm={12} md={4} key={card.id}>


### PR DESCRIPTION
### Ticket(s)

https://airtable.com/appfJZShN8K4tcWHU/pagxblGyhI5EJIA3v?HjEAY=recv3HaBRSb5GQw6Y

### Type of change

_Please delete any options that are not relevant_

- [X] Bug fix (non-breaking change which fixes an issue)

### Description

This commit addresses layout and responsiveness issues on the 'get-involved' page. The "waysToParticipate" grid was decentralized, leading to problems on mobile devices and an overflow issue along the x-axis. The header layout was disrupted as a result.

### Screenshots

#### Before

![Screenshot_2](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/8b1da5f6-032a-4c38-b845-c15ef21c0bf0)
![Screenshot_3](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/6d761ade-8d01-449d-93d0-1513cd14589c)

#### After

![Screenshot_4](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/3028b559-b0b7-4cd8-8213-a2b1694b58e4)
![Screenshot_5](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/dc4eb2c9-2dd3-4aa4-8793-1629e836618b)

### Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings in the console
- [X] There are no new linting errors/problems in my code
- [X] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
