### PR TITLE
Nemo 5727/update footer with address and less links

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -81,7 +81,7 @@ function Footer() {
           <Box sx={sectionHeaderStyles}>
             <Typography variant="h4">Links</Typography>
           </Box>
-          <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={8} maxWidth={400}>
+          <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={5} maxWidth={430}>
             {navItems
               .filter(
                 (item) => ['Get Started', 'Get Involved', 'About Us', 'Contact'].includes(item.text),
@@ -121,23 +121,23 @@ function Footer() {
 
         <Box sx={sectionContainerStyles}>
           <Box sx={sectionHeaderStyles}>
-            <Typography variant="h4">Partners</Typography>
+            <Typography variant="h4">Partnerships</Typography>
           </Box>
           <Stack
-            height="100%"
+            width={{ xs: '90%', md: '100%' }}
+            direction="row"
             alignItems="center"
-            justifyContent="center"
-            sx={{ flex: 1 }}
+            justifyContent="space-between"
+            spacing={3}
           >
             <Box>
               <ImageContainer
                 alt=""
                 src="/democracylab-logo.png"
-                width={412}
-                height={122}
+                width={206}
+                height={61}
                 useImageDimensions
                 style={{
-                  maxWidth: '200px',
                   width: '100%',
                   objectFit: 'contain',
                 }}
@@ -147,11 +147,9 @@ function Footer() {
               <ImageContainer
                 alt=""
                 src="/openseattle-logo.png"
-                width={130}
-                height={102}
-                useImageDimensions
+                width={124}
+                height={99}
                 style={{
-                  maxWidth: '200px',
                   width: '100%',
                   objectFit: 'contain',
                 }}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -3,6 +3,7 @@ import {
   Container,
   Divider,
   Grid,
+  Hidden,
   Link,
   Stack,
   SxProps,
@@ -10,15 +11,18 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import footerContent from '../../content/footer.ts';
 import navItems from '../../content/navItems.ts';
 import ImageContainer from './ImageContainer.tsx';
-import NavigationLogo from './NavigationLogo.tsx';
 
 const sectionContainerStyles: SxProps = {
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
-  alignItems: 'center',
+  alignItems: {
+    xs: 'center',
+    md: 'start',
+  },
 };
 
 const sectionHeaderStyles: SxProps = {
@@ -31,6 +35,7 @@ const sectionHeaderStyles: SxProps = {
 function Footer() {
   return (
     <Box
+      id="footer"
       component="footer"
       color="primary"
       sx={{
@@ -43,25 +48,30 @@ function Footer() {
         maxWidth="xl"
         sx={{
           display: 'flex',
-          textAlign: 'center',
+          textAlign: { xs: 'center', md: 'left' },
           padding: 2,
           flexDirection: { xs: 'column', md: 'row' },
           gap: 2,
         }}
       >
         <Box sx={sectionContainerStyles}>
-          <Box sx={sectionHeaderStyles}>
-            <NavigationLogo fullSize />
-          </Box>
-          <Typography variant="caption" gutterBottom>
-            Clearviction is reducing barriers faced by formerly incarcerated
-            individuals by streamlining the process of vacating eligible
-            convictions in Washington state.
-          </Typography>
-          <Typography variant="caption">
-            Clearviction is a registered 501(c)3 nonprofit organization,
-            EIN#88-3187952. All donations are tax deductible in full or in part.
-          </Typography>
+          <Hidden mdDown>
+            <Box sx={sectionHeaderStyles}>
+              <Typography variant="h4">Welcome!</Typography>
+            </Box>
+            <Box maxWidth="255px">
+              <Typography variant="caption" paragraph>
+                {footerContent.mission}
+              </Typography>
+              <Typography variant="caption" paragraph>
+                {footerContent.address.name}
+                <br />
+                {footerContent.address.street}
+                <br />
+                {footerContent.address.city}
+              </Typography>
+            </Box>
+          </Hidden>
         </Box>
 
         <Divider />

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -47,13 +47,13 @@ function Footer() {
     >
       <Container
         maxWidth="xl"
-        sx={{
+        sx={(theme) => ({
           display: 'flex',
           textAlign: { xs: 'center', md: 'left' },
-          padding: 2,
           flexDirection: { xs: 'column', md: 'row' },
-          gap: 2,
-        }}
+          p: { xs: theme.spacing(0, 9, 0, 9), md: theme.spacing(2, 9, 0, 9) },
+          gap: { xs: 2, md: 4 },
+        })}
       >
         <Box sx={sectionContainerStyles}>
           <Hidden mdDown>
@@ -81,7 +81,7 @@ function Footer() {
           <Box sx={sectionHeaderStyles}>
             <Typography variant="h4">Links</Typography>
           </Box>
-          <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={5} maxWidth={430}>
+          <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={5} maxWidth={400}>
             {navItems
               .filter(
                 (item) => ['Get Started', 'Get Involved', 'About Us', 'Contact'].includes(item.text),
@@ -157,6 +157,16 @@ function Footer() {
             </Box>
           </Stack>
         </Box>
+        <Hidden mdUp>
+          <Divider sx={{ borderBottom: '1px solid currentColor' }} />
+          <Typography variant="caption" paragraph>
+            {footerContent.address.name}
+            <br />
+            {footerContent.address.street}
+            <br />
+            {footerContent.address.city}
+          </Typography>
+        </Hidden>
       </Container>
 
       <Container
@@ -169,16 +179,6 @@ function Footer() {
           gap: 2,
         }}
       >
-        <Hidden mdUp>
-          <Divider sx={{ borderBottom: '1px solid currentColor' }} />
-          <Typography variant="caption" paragraph>
-            {footerContent.address.name}
-            <br />
-            {footerContent.address.street}
-            <br />
-            {footerContent.address.city}
-          </Typography>
-        </Hidden>
         <Box textAlign="center">
           <Typography variant="caption" paragraph>
             {footerContent.warning}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -27,7 +27,7 @@ const sectionContainerStyles: SxProps = {
 };
 
 const sectionHeaderStyles: SxProps = {
-  height: { xs: 48, md: 64 },
+  height: { xs: 40, md: 64 },
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -52,8 +52,8 @@ function Footer() {
           display: 'flex',
           textAlign: { xs: 'center', md: 'left' },
           flexDirection: { xs: 'column', md: 'row' },
-          p: { xs: theme.spacing(0, 9, 0, 9), md: theme.spacing(2, 9, 0, 9) },
-          gap: { xs: 0.5, md: 4 },
+          p: { xs: theme.spacing(4, 9, 0, 9), md: theme.spacing(10, 9, 0, 9) },
+          gap: { xs: 1, md: 4 },
         })}
       >
         <Box sx={sectionContainerStyles}>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -31,6 +31,7 @@ const sectionHeaderStyles: SxProps = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  pb: { xs: 0, md: 4 },
 };
 
 function Footer() {

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -144,12 +144,13 @@ function Footer() {
                 }}
               />
             </Box>
-            <Box>
+            <Box width={124}>
               <ImageContainer
                 alt=""
                 src="/openseattle-logo.png"
                 width={124}
                 height={99}
+                useImageDimensions
                 style={{
                   width: '100%',
                   objectFit: 'contain',

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -103,6 +103,7 @@ function Footer() {
                           xs: 'center',
                           md: 'space-between',
                         },
+                        alignItems: 'center',
                       }}
                     >
                       <Typography variant="subtitle2" margin="0">

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -158,6 +158,38 @@ function Footer() {
           </Stack>
         </Box>
       </Container>
+
+      <Container
+        maxWidth="xl"
+        sx={{
+          display: 'flex',
+          textAlign: 'center',
+          padding: 2,
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        <Hidden mdUp>
+          <Divider sx={{ borderBottom: '1px solid currentColor' }} />
+          <Typography variant="caption" paragraph>
+            {footerContent.address.name}
+            <br />
+            {footerContent.address.street}
+            <br />
+            {footerContent.address.city}
+          </Typography>
+        </Hidden>
+        <Box textAlign="center">
+          <Typography variant="caption" paragraph>
+            {footerContent.warning}
+          </Typography>
+
+          <Typography variant="caption" paragraph>
+            {footerContent.information}
+          </Typography>
+        </Box>
+      </Container>
+
     </Box>
   );
 }

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -27,7 +27,7 @@ const sectionContainerStyles: SxProps = {
 };
 
 const sectionHeaderStyles: SxProps = {
-  height: 64,
+  height: { xs: 48, md: 64 },
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -53,7 +53,7 @@ function Footer() {
           textAlign: { xs: 'center', md: 'left' },
           flexDirection: { xs: 'column', md: 'row' },
           p: { xs: theme.spacing(0, 9, 0, 9), md: theme.spacing(2, 9, 0, 9) },
-          gap: { xs: 2, md: 4 },
+          gap: { xs: 0.5, md: 4 },
         })}
       >
         <Box sx={sectionContainerStyles}>
@@ -80,7 +80,7 @@ function Footer() {
 
         <Box sx={sectionContainerStyles}>
           <Box sx={sectionHeaderStyles}>
-            <Typography variant="h4">Links</Typography>
+            <Typography variant="h4">Explore</Typography>
           </Box>
           <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={5} maxWidth={400}>
             {navItems
@@ -126,6 +126,7 @@ function Footer() {
           </Box>
           <Stack
             width={{ xs: '90%', md: '100%' }}
+            mb={1}
             direction="row"
             alignItems="center"
             justifyContent="space-between"
@@ -161,7 +162,7 @@ function Footer() {
         </Box>
         <Hidden mdUp>
           <Divider sx={{ borderBottom: '1px solid currentColor' }} />
-          <Typography variant="caption" paragraph>
+          <Typography variant="caption">
             {footerContent.address.name}
             <br />
             {footerContent.address.street}
@@ -185,7 +186,6 @@ function Footer() {
           <Typography variant="caption" paragraph>
             {footerContent.warning}
           </Typography>
-
           <Typography variant="caption" paragraph>
             {footerContent.information}
           </Typography>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -12,8 +12,7 @@ import {
 } from '@mui/material';
 import React from 'react';
 
-import footerContent from '../../content/footer.ts';
-import navItems from '../../content/navItems.ts';
+import { footerContent, footerNavItems } from '../../content/footer.ts';
 import ImageContainer from './ImageContainer.tsx';
 
 const sectionContainerStyles: SxProps = {
@@ -83,10 +82,7 @@ function Footer() {
             <Typography variant="h4">Explore</Typography>
           </Box>
           <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={5} maxWidth={400}>
-            {navItems
-              .filter(
-                (item) => ['Get Started', 'Get Involved', 'About Us', 'Contact'].includes(item.text),
-              )
+            {footerNavItems
               .map((item) => (
                 <Grid key={item.text} item xs={12} md={6}>
                   <Link

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,3 +1,4 @@
+import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import {
   Box,
   Container,
@@ -80,13 +81,13 @@ function Footer() {
           <Box sx={sectionHeaderStyles}>
             <Typography variant="h4">Links</Typography>
           </Box>
-          <Grid container spacing={1} maxWidth={300}>
+          <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={8} maxWidth={400}>
             {navItems
               .filter(
-                (item) => item.text !== 'Home' && item.text !== 'Access Calculator',
+                (item) => ['Get Started', 'Get Involved', 'About Us', 'Contact'].includes(item.text),
               )
               .map((item) => (
-                <Grid key={item.text} item xs={6}>
+                <Grid key={item.text} item xs={12} md={6}>
                   <Link
                     href={item.href}
                     color="primary.contrastText"
@@ -94,7 +95,22 @@ function Footer() {
                     fontSize={18}
                     noWrap
                   >
-                    {item.text}
+                    <Box
+                      display="flex"
+                      sx={{
+                        justifyContent: {
+                          xs: 'center',
+                          md: 'space-between',
+                        },
+                      }}
+                    >
+                      <Typography variant="subtitle2" margin="0">
+                        {item.text}
+                      </Typography>
+                      <Hidden mdDown>
+                        <ArrowRightIcon />
+                      </Hidden>
+                    </Box>
                   </Link>
                 </Grid>
               ))}

--- a/content/footer.ts
+++ b/content/footer.ts
@@ -1,4 +1,7 @@
-const footerContent = {
+import { NavItem } from './content.types.ts';
+import navItems from './navItems.ts';
+
+export const footerContent = {
   mission:
         'Clearviction is reducing barriers faced by formerly incarcerated individuals by streamlining the process of vacating eligible convictions in Washington state.',
   address: {
@@ -15,4 +18,14 @@ const footerContent = {
         'Clearviction is a registered 501(c)3 nonprofit organization, EIN#88-3187952.  All donations are tax deductible in full or in part. ',
 };
 
-export default footerContent;
+export const footerNavItems: NavItem[] = navItems
+  .filter(
+    (item) => ['Get Started', 'Get Involved', 'About Us', 'Contact'].includes(item.text),
+  )
+  .sort((a, b) => {
+    const order = ['Get Started', 'About Us', 'Get Involved', 'Contact'];
+    return order.indexOf(a.text) - order.indexOf(b.text);
+  })
+  .map((item) => (item.text === 'About Us'
+    ? { ...item, text: 'About' }
+    : item));

--- a/content/footer.ts
+++ b/content/footer.ts
@@ -1,0 +1,18 @@
+const footerContent = {
+  mission:
+        'Clearviction is reducing barriers faced by formerly incarcerated individuals by streamlining the process of vacating eligible convictions in Washington state.',
+  address: {
+    name:
+        'Clearviction c/o Seamus Brugh',
+    street:
+        '107 Spring St',
+    city:
+        'Seattle, WA 98104',
+  },
+  warning:
+        'The content on this website should not be treated as legal advice',
+  information:
+        'Clearviction is a registered 501(c)3 nonprofit organization, EIN#88-3187952.  All donations are tax deductible in full or in part. ',
+};
+
+export default footerContent;


### PR DESCRIPTION
### Ticket(s)

- https://airtable.com/appfJZShN8K4tcWHU/pagxblGyhI5EJIA3v?HjEAY=rec9voG6hM6BS7Io9

### Type of change

- [x] Design change

### Description

Implements new footer design. Adds address and more information to the footer, and changes the alignments.
The implementation has two differences with the design in mobile view mode: 
    1. The navItems are a bit farther for easier touching. 
    2. The font of the navItems remains subtitle2 in mobile mode in order to have a difference from its heading.

### Screenshots

#### Please include a screenshot of the Figma design file
<img width="664" alt="Footer_D_T" src="https://github.com/clearviction-devs/clearviction-wa/assets/29575804/fd80ccc2-d563-4c8d-8330-c0d60e4a3a91">
<img width="176" alt="Footer_M_T" src="https://github.com/clearviction-devs/clearviction-wa/assets/29575804/a03d72e6-6caa-4a26-a235-0fd9f1422fd4">


#### Before
<img width="1456" alt="footer_D_S" src="https://github.com/clearviction-devs/clearviction-wa/assets/29575804/c9c5529e-8f0f-4b76-ba6f-160e87b84676">
<img width="289" alt="Footer_M_S" src="https://github.com/clearviction-devs/clearviction-wa/assets/29575804/bc1d6058-87f9-4f67-be2a-7feeed34dfe1">

#### After
<img width="861" alt="Screenshot 2023-08-15 at 5 25 16 PM" src="https://github.com/clearviction-devs/clearviction-wa/assets/29575804/aa39cb90-2031-4f44-b2d6-3d8ede8c9f55">
<img width="228" alt="Screenshot 2023-08-15 at 5 25 34 PM" src="https://github.com/clearviction-devs/clearviction-wa/assets/29575804/93784761-2683-4530-8b17-71091fff5e4b">

### Checklist:

_Please delete any options that are not relevant_

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
