### PR TITLE
fix: resolve navbar overflow-x issue in certain screen sizes

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -145,7 +145,7 @@ export default function Header() {
                 display: 'flex',
                 justifyContent: 'flex-start',
                 py: 1,
-                px: 4,
+                px: { md: 3, lg: 4 },
                 maxWidth: '1100px',
               }}
             >
@@ -162,7 +162,7 @@ export default function Header() {
                     size="small"
                     className="nav-list__item"
                     sx={{
-                      whiteSpace: 'nowrap', marginLeft: { md: 0 }, px: 3, py: 1,
+                      whiteSpace: 'nowrap', marginLeft: { md: 0 }, px: { md: 2, lg: 3 }, py: 1,
                     }}
                   >
                     {item.text}


### PR DESCRIPTION
### Ticket(s)

https://airtable.com/appfJZShN8K4tcWHU/paghvE9diS74Z0Csc?c7fi2=recHohD7PXFrHeFly

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Description

Fixed the CSS overflow-x issue occurring in the header when the screen width fell within the range of 900px to 996px. Adjusted the styling to ensure proper display and prevent horizontal scrolling.

Fixes # 354

### Screenshots

#### Before

![image](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/028597d9-9cc1-4a5a-b9df-8fac543e578b)
![image](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/31735057-6bda-463a-9a2e-345cc65a0fd0)

#### After

![image](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/25435ae8-33fd-44c6-8d60-a99c604a5d45)


### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
