### PR TITLE
Add meta tag for google site verification

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -59,6 +59,7 @@ export default class MyDocument extends Document {
           />
           <link rel="manifest" href="/site.webmanifest" />
           <meta name="emotion-insertion-point" content="" />
+          <meta name="google-site-verification" content="KCnoZn7O-gYJ4Loa2Wzn7iosA1gxamx9iOOMVLCkaVA" />
 
           {(this.props as any).emotionStyleTags}
 


### PR DESCRIPTION
### Description

In order to get our website rescraped by Google, without adding DNS records to do so, we can use this verification meta tag. I made this PR against main so that I can complete the rest of the steps on the Google search console.

