### PR TITLE
6562 Fix homepage image bugs

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -148,7 +148,6 @@ function Footer() {
                 src="/openseattle-logo.png"
                 width={124}
                 height={99}
-                useImageDimensions
                 style={{
                   width: '100%',
                   objectFit: 'contain',

--- a/components/layout/ResearchBanner.tsx
+++ b/components/layout/ResearchBanner.tsx
@@ -45,7 +45,7 @@ export default function ResearchBanner() {
               alt=""
               width={406}
               height={306}
-              style={{ width: '100%' }}
+              style={{ width: '100%', height: 'auto' }}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
### Ticket(s)

- _[[Airtable ticket 6562](https://airtable.com/appfJZShN8K4tcWHU/pagxblGyhI5EJIA3v?HjEAY=recHTeru3ajdF9FCw)]_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

The image in the research banner as well as the open seattle logo in the footer had warnings in the console about the height and width being set improperly, basically setting one without the other, and this PR resolves both. In the research banner this adds a `height: auto` to the style prop, and in the footer, remove `useImageDimensions`, since the component is also simultaneously setting a new width, which was contradictory.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
