### PR TITLE
NEMO-6362 error messages and validation in contact form

### DIFF
--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -74,6 +74,7 @@ export default function ContactPage() {
       setFormError(`Please correct the following issues before submitting: ${errors.join(', ')}`);
     } else {
       setFormError('');
+      (e.target as HTMLFormElement).submit()
     }
   };
 

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -74,7 +74,7 @@ export default function ContactPage() {
       setFormError(`Please correct the following issues before submitting: ${errors.join(', ')}`);
     } else {
       setFormError('');
-      (e.target as HTMLFormElement).submit()
+      (e.target as HTMLFormElement).submit();
     }
   };
 

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -198,6 +198,7 @@ export default function ContactPage() {
             error={Boolean(formErrors.message)}
             placeholder={content.form.placeholders.message}
             aria-label={content.form.ariaLabels.message}
+            label={content.form.ariaLabels.message}
             aria-required="true"
             aria-describedby="message-helper-text"
             aria-invalid={Boolean(formErrors.message)}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Button, MenuItem, TextField, Typography,
+  Box, Button, FormHelperText, MenuItem, TextField, Typography,
 } from '@mui/material';
 import MuiMarkdown from 'mui-markdown';
 import React, { useState } from 'react';
@@ -10,37 +10,70 @@ import SectionContainer from '../components/layout/SectionContainer.tsx';
 import content from '../content/contact.ts';
 
 export default function ContactPage() {
-  const [toSend, setToSend] = useState({
+  interface FormData {
+    name: string;
+    _replyto: string;
+    contact_type: string;
+    message: string;
+}
+
+  const initialState: FormData = {
     name: '',
     _replyto: '',
     contact_type: '',
     message: '',
-  });
-
-  const [emailError, setEmailError] = useState({
-    errorStatus: false,
-    errorMessage: '',
-  });
-
-  const validateEmail = (email: string) => {
-    const validEmail = /\S+@\S+\.\S+/;
-    if (validEmail.test(email)) {
-      setEmailError({ errorStatus: false, errorMessage: '' });
-    } else {
-      setEmailError({
-        errorStatus: true,
-        errorMessage: 'Please enter a valid email',
-      });
-    }
   };
 
-  const handleChange = (e: React.ChangeEvent<any>) => {
-    setToSend({
-      ...toSend,
-      [(e.target as HTMLInputElement).name]: e.target.value,
+  const [toSend, setToSend] = useState<FormData>(initialState);
+  const [formError, setFormError] = useState<string>('');
+  const [formErrors, setFormErrors] = useState<FormData>(initialState);
+
+  const validateField = (key: keyof FormData, value: string): boolean => {
+    let error = '';
+
+    switch (key) {
+      case 'name':
+        if (!value.trim()) error = 'Name field is required';
+        else if (value.trim().split(' ').filter(Boolean).length < 2) { error = 'Please enter your first and last name'; }
+        break;
+      case '_replyto': {
+        const validEmail: RegExp = /\S+@\S+\.\S+/;
+        if (!validEmail.test(value)) error = 'Please enter a valid email, example: example@example.com';
+        break; }
+      case 'contact_type':
+        if (!value) error = 'Please select a contact type';
+        break;
+      case 'message':
+        if (!value.trim()) error = 'Message cannot be empty.';
+        break;
+      default:
+        break;
+    }
+
+    setFormErrors({ ...formErrors, [key]: error });
+    return !error;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setToSend({ ...toSend, [name]: value });
+    validateField(name as keyof FormData, value);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const errors: string[] = [];
+
+    Object.entries(toSend).forEach(([key, value]) => {
+      if (!validateField(key as keyof FormData, value)) {
+        errors.push(`${key}: ${formErrors[key as keyof FormData]}`);
+      }
     });
-    if (e.target.name === '_replyto') {
-      validateEmail(e.target.value);
+
+    if (errors.length) {
+      setFormError(`Please correct the following issues before submitting: ${errors.join(', ')}`);
+    } else {
+      setFormError('');
     }
   };
 
@@ -79,6 +112,7 @@ export default function ContactPage() {
             width: { xs: '85%', sm: '70%', md: '40%' },
             '& .MuiTextField-root': { m: 1 },
           }}
+          onSubmit={handleSubmit}
         >
           <TextField
             id="name"
@@ -91,22 +125,37 @@ export default function ContactPage() {
             fullWidth
             aria-label={content.form.ariaLabels.name}
             label={content.form.labels.name}
+            aria-required="true"
+            onBlur={() => validateField('name', toSend.name)}
+            error={Boolean(formErrors.name)}
+            aria-invalid={Boolean(formErrors.name)}
+            aria-labelledby="name"
+            aria-describedby="name-helper-text"
           />
+          <FormHelperText id="name-helper-text" error={Boolean(formErrors.name)} aria-live="assertive">
+            {formErrors.name}
+          </FormHelperText>
           <TextField
             id="email"
             name="_replyto"
             autoComplete="email"
             type="email"
             placeholder={content.form.placeholders.email}
-            error={emailError.errorStatus}
-            helperText={emailError.errorMessage}
+            error={Boolean(formErrors._replyto)}
             required
             value={toSend._replyto}
             onChange={handleChange}
+            onBlur={() => validateField('_replyto', toSend._replyto)}
             fullWidth
             aria-label={content.form.ariaLabels.email}
             label={content.form.labels.email}
+            aria-required="true"
+            aria-describedby="email-helper-text"
+            aria-invalid={Boolean(formErrors._replyto)}
           />
+          <FormHelperText id="email-helper-text" error aria-live="polite">
+            {formErrors._replyto}
+          </FormHelperText>
           <TextField
             id="contact_type"
             name="contact_type"
@@ -118,6 +167,11 @@ export default function ContactPage() {
             value={toSend.contact_type}
             onChange={handleChange}
             aria-label={content.form.ariaLabels.contactType}
+            error={Boolean(formErrors.contact_type)}
+            aria-required="true"
+            aria-invalid={Boolean(formErrors.contact_type)}
+            aria-describedby="contact-helper-text"
+            onBlur={() => validateField('contact_type', toSend.contact_type)}
           >
 
             {content.contactTypes.map((option) => (
@@ -127,6 +181,9 @@ export default function ContactPage() {
             ))}
 
           </TextField>
+          <FormHelperText id="contact-helper-text" error aria-live="polite">
+            {formErrors.contact_type}
+          </FormHelperText>
           <TextField
             id="message"
             name="message"
@@ -138,10 +195,22 @@ export default function ContactPage() {
             fullWidth
             onChange={handleChange}
             type="text"
+            error={Boolean(formErrors.message)}
             placeholder={content.form.placeholders.message}
             aria-label={content.form.ariaLabels.message}
+            aria-required="true"
+            aria-describedby="message-helper-text"
+            aria-invalid={Boolean(formErrors.message)}
+            onBlur={() => validateField('message', toSend.message)}
           />
-
+          <FormHelperText id="message-helper-text" error aria-live="polite">
+            {formErrors.message}
+          </FormHelperText>
+          {formError && (
+          <FormHelperText id="formError" error aria-live="assertive">
+            {formError}
+          </FormHelperText>
+          )}
           <Button
             sx={{ margin: '30px auto 50px', minWidth: '240px' }}
             type="submit"


### PR DESCRIPTION
### Ticket(s)

_Required unless this is just a change to documentation._

- _[Airtable ticket 6362 4.1.3 status Messages](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recqjdooelGHdMfPK)_

### Type of change

_Please delete any options that are not relevant_

- [x] Bug/Fix


### Description

Update the status message on the contact form. The form should be accessible when tabbing through the form and the screen reader should read the inputs, and error messages inline as they occur. 



### Screenshots
<img width="1440" alt="image" src="https://github.com/clearviction-devs/clearviction-wa/assets/89257201/5b18a07e-50bd-4315-8faf-9f78abd0f5f0">
<img width="1440" alt="image" src="https://github.com/clearviction-devs/clearviction-wa/assets/89257201/7fc67b19-e3a5-40cf-a4c9-2ffb267ffb83">

### Checklist:

_Please delete any options that are not relevant_

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
