### PR TITLE
style: css selectors name on footer component

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -4,7 +4,6 @@ import {
   Container,
   Divider,
   Grid,
-  Hidden,
   Link,
   Stack,
   SxProps,
@@ -136,9 +135,9 @@ function Footer() {
                       <Typography variant="subtitle2" margin="0">
                         {item.text}
                       </Typography>
-                      <Hidden mdDown>
+                      <Box sx={{ display: { xs: 'none', md: 'block' } }}>
                         <ArrowRightIcon />
-                      </Hidden>
+                      </Box>
                     </Box>
                   </Link>
                 </Grid>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -8,12 +8,20 @@ import {
   Link,
   Stack,
   SxProps,
+  Theme,
   Typography,
+  TypographyProps,
 } from '@mui/material';
 import React from 'react';
 
 import { footerContent, footerNavItems } from '../../content/footer.ts';
 import ImageContainer from './ImageContainer.tsx';
+
+type FooterSectionProps = {
+  title: string;
+  children: React.ReactNode;
+  sx?: SxProps;
+}
 
 const sectionContainerStyles: SxProps = {
   flex: 1,
@@ -33,6 +41,41 @@ const sectionHeaderStyles: SxProps = {
   pb: { xs: 0, md: 4 },
 };
 
+const getFooterMainStyles = (theme: Theme) => ({
+  display: 'flex',
+  textAlign: { xs: 'center', md: 'left' },
+  flexDirection: { xs: 'column', md: 'row' },
+  p: { xs: theme.spacing(4, 9, 0, 9), md: theme.spacing(10, 9, 0, 9) },
+  gap: { xs: 1, md: 4 },
+});
+
+function FullAddress(props?: TypographyProps) {
+  return (
+    <Typography className="address" variant="caption" {...props}>
+      {footerContent.address.name}
+      <br />
+      {footerContent.address.street}
+      <br />
+      {footerContent.address.city}
+    </Typography>
+  );
+}
+
+function FooterSection({ title, children, sx }: FooterSectionProps) {
+  const footerSectionSx = { ...sectionContainerStyles, ...sx };
+  const transformTextInKebabCase = (text: string) => text.replace(/\s+/g, '-').toLowerCase();
+  const titleInKebabCase = transformTextInKebabCase(title);
+
+  return (
+    <Box className={`${titleInKebabCase}-section`} sx={footerSectionSx}>
+      <Box className={`${titleInKebabCase}-header`} sx={sectionHeaderStyles}>
+        <Typography variant="h4">{title}</Typography>
+      </Box>
+      {children}
+    </Box>
+  );
+}
+
 function Footer() {
   return (
     <Box
@@ -47,41 +90,28 @@ function Footer() {
     >
       <Container
         maxWidth="xl"
-        sx={(theme) => ({
-          display: 'flex',
-          textAlign: { xs: 'center', md: 'left' },
-          flexDirection: { xs: 'column', md: 'row' },
-          p: { xs: theme.spacing(4, 9, 0, 9), md: theme.spacing(10, 9, 0, 9) },
-          gap: { xs: 1, md: 4 },
-        })}
+        sx={getFooterMainStyles}
+        className="footer-main"
       >
-        <Box sx={sectionContainerStyles}>
-          <Hidden mdDown>
-            <Box sx={sectionHeaderStyles}>
-              <Typography variant="h4">Welcome!</Typography>
-            </Box>
-            <Box maxWidth="255px">
-              <Typography variant="caption" paragraph>
-                {footerContent.mission}
-              </Typography>
-              <Typography variant="caption" paragraph>
-                {footerContent.address.name}
-                <br />
-                {footerContent.address.street}
-                <br />
-                {footerContent.address.city}
-              </Typography>
-            </Box>
-          </Hidden>
-        </Box>
+        <FooterSection title="Welcome" sx={{ display: { xs: 'none', md: 'block' } }}>
+          <Box className="welcome-details" maxWidth="255px">
+            <Typography className="our-mission" variant="caption" paragraph>
+              {footerContent.mission}
+            </Typography>
+            <FullAddress paragraph />
+          </Box>
+        </FooterSection>
 
         <Divider />
 
-        <Box sx={sectionContainerStyles}>
-          <Box sx={sectionHeaderStyles}>
-            <Typography variant="h4">Explore</Typography>
-          </Box>
-          <Grid container rowSpacing={{ xs: 0, md: 5 }} columnSpacing={5} maxWidth={400}>
+        <FooterSection title="Explore">
+          <Grid
+            className="explore-grid"
+            container
+            rowSpacing={{ xs: 0, md: 5 }}
+            columnSpacing={5}
+            maxWidth={400}
+          >
             {footerNavItems
               .map((item) => (
                 <Grid key={item.text} item xs={12} md={6}>
@@ -91,6 +121,7 @@ function Footer() {
                     underline="hover"
                     fontSize={18}
                     noWrap
+                    className="explore-link"
                   >
                     <Box
                       display="flex"
@@ -113,14 +144,11 @@ function Footer() {
                 </Grid>
               ))}
           </Grid>
-        </Box>
+        </FooterSection>
 
         <Divider />
 
-        <Box sx={sectionContainerStyles}>
-          <Box sx={sectionHeaderStyles}>
-            <Typography variant="h4">Partnerships</Typography>
-          </Box>
+        <FooterSection title="Partnerships">
           <Stack
             width={{ xs: '90%', md: '100%' }}
             mb={1}
@@ -128,10 +156,11 @@ function Footer() {
             alignItems="center"
             justifyContent="space-between"
             spacing={3}
+            className="partnerships-logos"
           >
-            <Box>
+            <Box className="democracylab-logo">
               <ImageContainer
-                alt=""
+                alt="Democracylab logo"
                 src="/democracylab-logo.png"
                 width={206}
                 height={61}
@@ -142,9 +171,9 @@ function Footer() {
                 }}
               />
             </Box>
-            <Box width={124}>
+            <Box className="openseattle-logo" width={124}>
               <ImageContainer
-                alt=""
+                alt="Openseattle logo"
                 src="/openseattle-logo.png"
                 width={124}
                 height={99}
@@ -155,17 +184,12 @@ function Footer() {
               />
             </Box>
           </Stack>
-        </Box>
-        <Hidden mdUp>
+        </FooterSection>
+
+        <Box sx={{ display: { md: 'none', xs: 'block' } }}>
           <Divider sx={{ borderBottom: '1px solid currentColor' }} />
-          <Typography variant="caption">
-            {footerContent.address.name}
-            <br />
-            {footerContent.address.street}
-            <br />
-            {footerContent.address.city}
-          </Typography>
-        </Hidden>
+          <FullAddress />
+        </Box>
       </Container>
 
       <Container
@@ -177,12 +201,13 @@ function Footer() {
           flexDirection: 'column',
           gap: 2,
         }}
+        className="footer-bottom"
       >
         <Box textAlign="center">
-          <Typography variant="caption" paragraph>
+          <Typography className="warning" variant="caption" paragraph>
             {footerContent.warning}
           </Typography>
-          <Typography variant="caption" paragraph>
+          <Typography className="information" variant="caption" paragraph>
             {footerContent.information}
           </Typography>
         </Box>


### PR DESCRIPTION
### Ticket(s)

- _[[6345](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recIWN89Ap0OmZSmx)]_

### Type of change

- [x] Design change

### Description

- Some Footer components have either not declarative className or no className. Because of that debugging can sometimes be difficult.
- Footer has some repetitive sections that maybe could have a custom component (`FooterSection`).
- We are using the same full address in two different places, so would be interesting if we implement something (`FullAddress`) and use that where we need inside Footer. (Single Source of Truth)
- Footer is using `Hidden` MUI component, which is deprecated in MUI v5 ([Hidden](https://mui.com/material-ui/react-hidden/)), so a migration may be a good option.  

### Screenshots

#### Before
##### Had 3 Boxes like this
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/8b62855f-91d9-4ae7-9e1e-eb20666e7dd9)

#### After
##### FooterSection implmentation to use on sections
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/74daba2c-2ab3-4ea0-b9df-f97b5376877d)

#### Before
##### Had 2 places with that exact same Typography code
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/01f959db-7f8f-45a8-a5b1-9cbee467e668)

#### After
##### FullAddress component for use inside Footer component.
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/d449ac5f-f900-44b0-bcec-3a1c24135f47)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
