### PR TITLE
css selectors hero and research banner

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -135,7 +135,9 @@ function Footer() {
                       <Typography variant="subtitle2" margin="0">
                         {item.text}
                       </Typography>
-                      <Box sx={{ display: { xs: 'none', md: 'block' } }}>
+                      <Box
+                        sx={{ display: { xs: 'none', md: 'flex' } }}
+                      >
                         <ArrowRightIcon />
                       </Box>
                     </Box>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -36,7 +36,7 @@ const sectionHeaderStyles: SxProps = {
   height: { xs: 40, md: 64 },
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
+  justifyContent: 'start',
   pb: { xs: 0, md: 4 },
 };
 
@@ -92,7 +92,7 @@ function Footer() {
         sx={getFooterMainStyles}
         className="footer-main"
       >
-        <FooterSection title="Welcome" sx={{ display: { xs: 'none', md: 'block' } }}>
+        <FooterSection title="Welcome!" sx={{ display: { xs: 'none', md: 'block' } }}>
           <Box className="welcome-details" maxWidth="255px">
             <Typography className="our-mission" variant="caption" paragraph>
               {footerContent.mission}

--- a/components/layout/HeroBanner.tsx
+++ b/components/layout/HeroBanner.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   SxProps,
+  Theme,
   Typography,
   TypographyProps,
 } from '@mui/material';
@@ -19,7 +20,7 @@ interface HeroBannerProps {
   imgsrc?: string;
   ctaText?: string;
   ctaLink?: string;
-  children?: JSX.Element;
+  children?: JSX.Element | null;
   overrideStyles?: SxProps;
 }
 
@@ -29,6 +30,13 @@ const heroStyles: SxProps = {
   py: 8,
 };
 
+const getHeroAdditionalsStyles = (theme: Theme) => ({
+  display: 'flex',
+  margin: theme.spacing(3, 'auto'),
+  justifyContent: 'center',
+  order: { xs: '1', md: '2' },
+});
+
 export default function HeroBanner({
   header,
   subheading,
@@ -36,16 +44,17 @@ export default function HeroBanner({
   imgsrc,
   ctaText,
   ctaLink,
-  children,
+  children = null,
   overrideStyles,
 }: HeroBannerProps) {
   return (
-    <Box sx={overrideStyles || heroStyles} textAlign="left">
-      <SectionContainer sx={{}}>
-        <Typography variant="h1" sx={{ display: 'block' }}>
+    <Box className="hero-banner" sx={overrideStyles || heroStyles} textAlign="left">
+      <SectionContainer>
+        <Typography className="hero-title" variant="h1" sx={{ display: 'block' }}>
           {header}
         </Typography>
         <Box
+          className="hero-content"
           sx={{
             display: 'flex',
             flexWrap: 'wrap',
@@ -53,7 +62,7 @@ export default function HeroBanner({
           }}
         >
           <Box sx={{ flex: 1, order: { xs: '2', md: '1' } }}>
-            <Box sx={{ mt: 2, mb: 4 }}>
+            <Box className="subheading" sx={{ mt: 2, mb: 4 }}>
               <MuiMarkdown
                 overrides={{
                   p: {
@@ -85,7 +94,7 @@ export default function HeroBanner({
 
             </Box>
             {subheading2 && (
-            <Box sx={{ mb: 4 }}>
+            <Box className="subheading-secondary" sx={{ mb: 4 }}>
               <MuiMarkdown
                 overrides={{
                   p: {
@@ -128,14 +137,10 @@ export default function HeroBanner({
           </Box>
           {(imgsrc || children) && (
             <Box
-              sx={(theme) => ({
-                display: 'flex',
-                margin: theme.spacing(3, 'auto'),
-                justifyContent: 'center',
-                order: { xs: '1', md: '2' },
-              })}
+              className="hero-additionals"
+              sx={getHeroAdditionalsStyles}
             >
-              {imgsrc ? (
+              {imgsrc && (
                 <ImageContainer
                   src={imgsrc}
                   width={513}
@@ -144,9 +149,8 @@ export default function HeroBanner({
                   style={{ maxWidth: '100%' }}
                   useImageDimensions
                 />
-              ) : (
-                children
               )}
+              {children}
             </Box>
           )}
         </Box>

--- a/components/layout/ResearchBanner.tsx
+++ b/components/layout/ResearchBanner.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Button, Grid, SxProps, Typography,
+  Box, Button, Grid, SxProps, Theme, Typography,
 } from '@mui/material';
 import React from 'react';
 
@@ -12,14 +12,23 @@ const researchBannerStyles: SxProps = {
   py: 4,
 };
 
+const getButtonStyles = (theme: Theme) => ({
+  backgroundColor: theme.palette.primary.contrastText,
+  color: 'black',
+  '&:hover': {
+    color: theme.palette.primary.contrastText,
+    backgroundColor: theme.palette.primary.dark,
+  },
+});
+
 const researchFormLink: string = 'https://airtable.com/appfJZShN8K4tcWHU/shrHf25Nfh7LMhwZg';
 
 export default function ResearchBanner() {
   return (
-    <Box sx={researchBannerStyles}>
+    <Box className="research-banner" sx={researchBannerStyles}>
       <SectionContainer>
         <Grid container alignItems="center">
-          <Grid item xs={12} sm={6} md={8}>
+          <Grid className="research-banner-content" item xs={12} sm={6} md={8}>
             <Typography variant="h3" gutterBottom>
               Help improve our services!
             </Typography>
@@ -27,19 +36,12 @@ export default function ResearchBanner() {
               fullWidth
               variant="contained"
               href={researchFormLink}
-              sx={(theme) => ({
-                backgroundColor: theme.palette.primary.contrastText,
-                color: 'black',
-                '&:hover': {
-                  color: theme.palette.primary.contrastText,
-                  backgroundColor: theme.palette.primary.dark,
-                },
-              })}
+              sx={getButtonStyles}
             >
               Share your experience
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6} md={4}>
+          <Grid className="research-banner-img" item xs={12} sm={6} md={4}>
             <ImageContainer
               src="/illustrations/checklist1.svg"
               alt=""


### PR DESCRIPTION
### Ticket(s)

- [[6344](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recOljFtIzjb5eZR1)]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Hero Banner and Research banner are light on Css selectors, which makes debugging hard.
- Added CSS selectores on Hero Banner  and Research Banner
- Adjusted Footer component on `Welcome` section, because it was not how style was expected
- Align arrows on Footer Explore grid.

### Screenshots

#### Before
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/c3f55f11-e3fb-4bd6-9948-f3fde4a8153e)

#### After
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/30353481-6aad-4fe9-9d69-3bfc630567fd)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
