### PR TITLE
Nemo 7358/fix href scroll

### DIFF
--- a/components/functional/CustomScroll.tsx
+++ b/components/functional/CustomScroll.tsx
@@ -1,32 +1,24 @@
-import { useEffect } from 'react';
+function useScroll() {
+  let headerHeight: number | null = null;
+  if (typeof window !== 'undefined') {
+    const header = document.getElementById('main-header');
+    headerHeight = header?.clientHeight || null;
+  }
 
-// open all external links in another tab
-export default function CustomScroll() {
-  useEffect(() => {
-    // Defining a function to handle click events on the navigation menu links
-    const handleLinkClick = (event : any) => {
-      event.preventDefault();
-      const target = event.target.getAttribute('data-href'); // Get the custom attribute
-      const element = document.querySelector(target);
-      if (element) {
-        const topOffset = element.offsetTop;
-        window.scrollTo({
-          top: topOffset - 200,
-          behavior: 'smooth',
-        });
-      }
-    };
-
-    // Select buttons with the custom attribute
-    const links = document.querySelectorAll('[data-href^="#"]');
-    links.forEach((link) => {
-      link.addEventListener('click', handleLinkClick);
-    });
-
-    return () => {
-      links.forEach((link) => {
-        link.removeEventListener('click', handleLinkClick);
+  const handleLinkClick = (event: any) => {
+    event.preventDefault();
+    const target = event.target.getAttribute('data-href');
+    const element = document.querySelector(target);
+    if (element && headerHeight) {
+      const topOffset = element.offsetTop;
+      window.scrollTo({
+        top: topOffset - headerHeight,
+        behavior: 'smooth',
       });
-    };
-  }, []);
+    }
+  };
+
+  return { handleLinkClick };
 }
+
+export default useScroll;

--- a/components/functional/CustomScroll.tsx
+++ b/components/functional/CustomScroll.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+// open all external links in another tab
+export default function CustomScroll() {
+  useEffect(() => {
+    // Defining a function to handle click events on the navigation menu links
+    const handleLinkClick = (event : any) => {
+      event.preventDefault();
+      const target = event.target.getAttribute('data-href'); // Get the custom attribute
+      const element = document.querySelector(target);
+      if (element) {
+        const topOffset = element.offsetTop;
+        window.scrollTo({
+          top: topOffset - 200,
+          behavior: 'smooth',
+        });
+      }
+    };
+
+    // Select buttons with the custom attribute
+    const links = document.querySelectorAll('[data-href^="#"]');
+    links.forEach((link) => {
+      link.addEventListener('click', handleLinkClick);
+    });
+
+    return () => {
+      links.forEach((link) => {
+        link.removeEventListener('click', handleLinkClick);
+      });
+    };
+  }, []);
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -64,7 +64,7 @@ export default function Header() {
     <>
       {/* hide until we figure out what the cta is supposed to be */}
       {/* <GivingTuesdayBanner /> */}
-      <AppBar className="nav-desktop" color="primary" elevation={0} component="nav" position="sticky">
+      <AppBar id="main-header" className="nav-desktop" color="primary" elevation={0} component="nav" position="sticky">
         <Container maxWidth="xl" sx={{ p: 3 }}>
           <Toolbar disableGutters sx={{ height: { xs: 64 } }}>
             <SkipLink color="primary" variant="contained" />

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -8,7 +8,7 @@ import MuiMarkdown from 'mui-markdown';
 import Link from 'next/link';
 import React from 'react';
 
-import useScroll from '../components/functional/CustomScroll';
+import useScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import FactCard from '../components/layout/FactCard.tsx';

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -8,6 +8,7 @@ import MuiMarkdown from 'mui-markdown';
 import Link from 'next/link';
 import React from 'react';
 
+import CustomScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import FactCard from '../components/layout/FactCard.tsx';
@@ -22,6 +23,7 @@ export default function AboutPage() {
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
 
   externalLinks();
+  CustomScroll();
 
   return (
     <>
@@ -43,10 +45,10 @@ export default function AboutPage() {
           fullWidth
           orientation={matchesXS ? 'vertical' : 'horizontal'}
         >
-          <Button href={content.buttons[0].href}>{content.buttons[0].name}</Button>
-          <Button href={content.buttons[1].href}>{content.buttons[1].name}</Button>
-          <Button href={content.buttons[2].href}>{content.buttons[2].name}</Button>
-          <Button href={content.buttons[3].href}>{content.buttons[3].name}</Button>
+          <Button data-href={content.buttons[0].href}>{content.buttons[0].name}</Button>
+          <Button data-href={content.buttons[1].href}>{content.buttons[1].name}</Button>
+          <Button data-href={content.buttons[2].href}>{content.buttons[2].name}</Button>
+          <Button data-href={content.buttons[3].href}>{content.buttons[3].name}</Button>
         </ButtonGroup>
       </SectionContainer>
 

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -8,7 +8,7 @@ import MuiMarkdown from 'mui-markdown';
 import Link from 'next/link';
 import React from 'react';
 
-import CustomScroll from '../components/functional/CustomScroll.tsx';
+import useScroll from '../components/functional/CustomScroll';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import FactCard from '../components/layout/FactCard.tsx';
@@ -21,9 +21,9 @@ import content from '../content/about.ts';
 export default function AboutPage() {
   const theme = useTheme();
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
+  const { handleLinkClick } = useScroll();
 
   externalLinks();
-  CustomScroll();
 
   return (
     <>
@@ -45,10 +45,30 @@ export default function AboutPage() {
           fullWidth
           orientation={matchesXS ? 'vertical' : 'horizontal'}
         >
-          <Button data-href={content.buttons[0].href}>{content.buttons[0].name}</Button>
-          <Button data-href={content.buttons[1].href}>{content.buttons[1].name}</Button>
-          <Button data-href={content.buttons[2].href}>{content.buttons[2].name}</Button>
-          <Button data-href={content.buttons[3].href}>{content.buttons[3].name}</Button>
+          <Button
+            data-href={content.buttons[0].href}
+            onClick={handleLinkClick}
+          >
+            {content.buttons[0].name}
+          </Button>
+          <Button
+            data-href={content.buttons[1].href}
+            onClick={handleLinkClick}
+          >
+            {content.buttons[1].name}
+          </Button>
+          <Button
+            data-href={content.buttons[2].href}
+            onClick={handleLinkClick}
+          >
+            {content.buttons[2].name}
+          </Button>
+          <Button
+            data-href={content.buttons[3].href}
+            onClick={handleLinkClick}
+          >
+            {content.buttons[3].name}
+          </Button>
         </ButtonGroup>
       </SectionContainer>
 

--- a/pages/get-started.tsx
+++ b/pages/get-started.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
-import CustomScroll from '../components/functional/CustomScroll.tsx';
+import useScroll from '../components/functional/CustomScroll';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';
@@ -20,9 +20,9 @@ import content from '../content/get-started.ts';
 export default function GetStartedPage() {
   const theme = useTheme();
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
+  const { handleLinkClick } = useScroll();
 
   externalLinks();
-  CustomScroll();
 
   return (
     <>
@@ -50,6 +50,7 @@ export default function GetStartedPage() {
               <Button
                 key={button.href}
                 data-href={button.href}
+                onClick={handleLinkClick}
               >
                 {button.name}
               </Button>

--- a/pages/get-started.tsx
+++ b/pages/get-started.tsx
@@ -6,6 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
+import CustomScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';
@@ -21,6 +22,7 @@ export default function GetStartedPage() {
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
 
   externalLinks();
+  CustomScroll();
 
   return (
     <>
@@ -47,7 +49,7 @@ export default function GetStartedPage() {
             content.buttons.map((button) => (
               <Button
                 key={button.href}
-                href={button.href}
+                data-href={button.href}
               >
                 {button.name}
               </Button>

--- a/pages/get-started.tsx
+++ b/pages/get-started.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
-import useScroll from '../components/functional/CustomScroll';
+import useScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
+import CustomScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import MailchimpForm from '../components/functional/MailchimpForm.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
@@ -23,6 +24,7 @@ export default function Home() {
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
 
   externalLinks();
+  CustomScroll();
 
   return (
     <>
@@ -42,7 +44,7 @@ export default function Home() {
             orientation={matchesXS ? 'vertical' : 'horizontal'}
           >
             {content.sectionNavs.map((nav) => (
-              <Button key={nav.href} href={nav.href}>
+              <Button key={nav.href} data-href={nav.href}>
                 {nav.label}
               </Button>
             ))}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
-import useScroll from '../components/functional/CustomScroll';
+import useScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import MailchimpForm from '../components/functional/MailchimpForm.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
-import CustomScroll from '../components/functional/CustomScroll.tsx';
+import useScroll from '../components/functional/CustomScroll';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import MailchimpForm from '../components/functional/MailchimpForm.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
@@ -22,9 +22,9 @@ import content from '../content/home.ts';
 export default function Home() {
   const theme = useTheme();
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
+  const { handleLinkClick } = useScroll();
 
   externalLinks();
-  CustomScroll();
 
   return (
     <>
@@ -44,7 +44,7 @@ export default function Home() {
             orientation={matchesXS ? 'vertical' : 'horizontal'}
           >
             {content.sectionNavs.map((nav) => (
-              <Button key={nav.href} data-href={nav.href}>
+              <Button key={nav.href} data-href={nav.href} onClick={handleLinkClick}>
                 {nav.label}
               </Button>
             ))}

--- a/pages/why-vacate.tsx
+++ b/pages/why-vacate.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 
-import useScroll from '../components/functional/CustomScroll';
+import useScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';

--- a/pages/why-vacate.tsx
+++ b/pages/why-vacate.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 
+import CustomScroll from '../components/functional/CustomScroll.tsx';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';
@@ -19,6 +20,7 @@ export default function WhyVacatePage() {
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
 
   externalLinks();
+  CustomScroll();
 
   return (
     <>
@@ -40,7 +42,7 @@ export default function WhyVacatePage() {
           orientation={matchesXS ? 'vertical' : 'horizontal'}
         >
           {content.buttons.map((button: any) => (
-            <Button key={button.name} href={button.href}>
+            <Button key={button.name} data-href={button.href}>
               {button.name}
             </Button>
           ))}

--- a/pages/why-vacate.tsx
+++ b/pages/why-vacate.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 
-import CustomScroll from '../components/functional/CustomScroll.tsx';
+import useScroll from '../components/functional/CustomScroll';
 import externalLinks from '../components/functional/ExternalLinks.tsx';
 import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
 import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';
@@ -18,9 +18,9 @@ import content from '../content/why-vacate.ts';
 export default function WhyVacatePage() {
   const theme = useTheme();
   const matchesXS = useMediaQuery(theme.breakpoints.down('sm'));
+  const { handleLinkClick } = useScroll();
 
   externalLinks();
-  CustomScroll();
 
   return (
     <>
@@ -42,7 +42,7 @@ export default function WhyVacatePage() {
           orientation={matchesXS ? 'vertical' : 'horizontal'}
         >
           {content.buttons.map((button: any) => (
-            <Button key={button.name} data-href={button.href}>
+            <Button key={button.name} data-href={button.href} onClick={handleLinkClick}>
               {button.name}
             </Button>
           ))}


### PR DESCRIPTION
### Ticket(s)

[7358](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rec0agbQRpUgFN61O)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

All href links on all pages are not scrolling properly due to our navbar's size (200px tall). One possible solution is to inspect these href components and make them scroll to a position -200 pixels, so that they can account for the navbar's size. I've added images of the scrolling final position before and after the changes.

### Screenshots

#### Before
![normal1](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/9ed46eb2-78ac-4e37-bb68-629e72a448b7)
![normal2](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/dcdfbc52-8ba3-4dca-87b2-d053af200374)
![normal3](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/e6e03593-4a08-462d-87ac-6417c6af2756)
#### After
![custom1](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/69c7e32a-c22e-4dc1-9672-c0a6a40d7995)
![custom2](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/2c131d49-d9a0-493c-b531-3a90a9089767)
![custom3](https://github.com/clearviction-devs/clearviction-wa/assets/52424334/e0a0e763-4f52-4184-8a40-d2bde9b798b1)

### Checklist:

_Please delete any options that are not relevant_

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
