### PR TITLE
Tf 6347/add css selectors to about contact

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -44,6 +44,7 @@ export default function AboutPage() {
           variant="text"
           fullWidth
           orientation={matchesXS ? 'vertical' : 'horizontal'}
+          id="about-nav"
         >
           <Button
             data-href={content.buttons[0].href}
@@ -72,7 +73,7 @@ export default function AboutPage() {
         </ButtonGroup>
       </SectionContainer>
 
-      <SectionContainer sx={{ margin: 'auto', mb: 4, maxWidth: '65rem' }} maxWidth={false}>
+      <SectionContainer sx={{ margin: 'auto', mb: 4, maxWidth: '65rem' }} maxWidth={false} id="our-mission-header">
         <Typography variant="h3">{content.ourMission.header}</Typography>
       </SectionContainer>
 
@@ -90,7 +91,7 @@ export default function AboutPage() {
         </Box>
 
         <Box>
-          <PaperSection title="" sx={{ p: 8, my: 8 }}>
+          <PaperSection title="" sx={{ p: 8, my: 8 }} id="about-facts">
             <Grid container spacing={4}>
               <Grid container className="fact-card">
                 {content.facts.map((fact) => (
@@ -124,7 +125,7 @@ export default function AboutPage() {
 
       </SectionContainer>
 
-      <SectionContainer sx={{ margin: 'auto', maxWidth: '65rem' }} maxWidth={false}>
+      <SectionContainer sx={{ margin: 'auto', maxWidth: '65rem' }} maxWidth={false} id="join-us">
         <Box>
           <Grid container>
             <Grid item xs={12}>
@@ -143,10 +144,10 @@ export default function AboutPage() {
               />
             </Grid>
             <Grid item sm={12} md={6}>
-              <Typography variant="subtitle1" sx={{ mt: '4.375rem', textAlign: 'center' }}>
+              <Typography variant="subtitle1" sx={{ mt: '4.375rem', textAlign: 'center' }} id="join-us-body">
                 <MuiMarkdown>{content.joinUs.body}</MuiMarkdown>
               </Typography>
-              <Stack sx={{ direction: 'column' }}>
+              <Stack sx={{ direction: 'column' }} id="join-us-buttons">
                 <Button href="/donate" variant="contained" sx={{ width: '15.5rem' }}>{content.buttons[5].name}</Button>
                 <Button href="/get-involved" variant="contained" sx={{ width: '15.5rem' }}>{content.buttons[6].name}</Button>
               </Stack>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -49,24 +49,28 @@ export default function AboutPage() {
           <Button
             data-href={content.buttons[0].href}
             onClick={handleLinkClick}
+            id="our-story-button"
           >
             {content.buttons[0].name}
           </Button>
           <Button
             data-href={content.buttons[1].href}
             onClick={handleLinkClick}
+            id="our-partners-button"
           >
             {content.buttons[1].name}
           </Button>
           <Button
             data-href={content.buttons[2].href}
             onClick={handleLinkClick}
+            id="our-officers-button"
           >
             {content.buttons[2].name}
           </Button>
           <Button
             data-href={content.buttons[3].href}
             onClick={handleLinkClick}
+            id="our-team-button"
           >
             {content.buttons[3].name}
           </Button>

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -85,7 +85,7 @@ export default function ContactPage() {
         metaContent={content.meta.content}
       />
 
-      <SectionContainer sx={{ textAlign: 'center', mt: 5 }}>
+      <SectionContainer sx={{ textAlign: 'center', mt: 5 }} id="contact-header">
         <Typography variant="h1" sx={{ textAlign: 'center' }}>
           {content.title}
         </Typography>
@@ -100,6 +100,7 @@ export default function ContactPage() {
           display: 'flex',
           flexDirection: { xs: 'column', sm: 'column', md: 'row' },
         }}
+        id="contact-body"
       >
         <Box
           component="form"
@@ -218,6 +219,7 @@ export default function ContactPage() {
             sx={{ margin: '30px auto 50px', minWidth: '240px' }}
             type="submit"
             variant="contained"
+            id="contact-submit-button"
           >
             {content.sendButtonText}
           </Button>

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -219,7 +219,6 @@ export default function ContactPage() {
             sx={{ margin: '30px auto 50px', minWidth: '240px' }}
             type="submit"
             variant="contained"
-            id="contact-submit-button"
           >
             {content.sendButtonText}
           </Button>


### PR DESCRIPTION
### Ticket(s)

- [6347](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rec9jzRRavJ6ZUHQi)

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Description

I think our about and contact pages were pretty good in terms of CSS selectors. The additional id's I added in either help differentiate container elements on pages, or in the case of some buttons, add clarity to elements that are being rendered through content data. The contact form already has a significant amount of selectors, so I refrained from adding any there.
I went with id's instead of classnames because many of the materialUI elements already have many classnames. 

### Screenshots

No relevant screenshots as the only changes were adding additional id values to elements

### Checklist:

_Please delete any options that are not relevant_

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings in the console
- [X] There are no new linting errors/problems in my code
- [X] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
