### PR TITLE
Add aria-label to nav buttons using lower case names

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -158,6 +158,7 @@ export default function Header() {
                   <Button
                     key={item.text}
                     href={item.href}
+                    aria-label={`${item.text.toLowerCase()}`}
                     variant="text"
                     color="neutral"
                     size="small"


### PR DESCRIPTION
### Ticket(s)

_Required unless this is just a change to documentation._

- [7768](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rec8uCGbxDHmnbohQ)

### Type of change

_Please delete any options that are not relevant_

- [X] Bug fix (non-breaking change which fixes an issue)

### Description

When using a voice reader, sometimes the Reader reads instances of `ABOUT US` incorrectly. The only instance I found of this is in the NavBar because the Button text is all caps. I added an aria-label to correct this issue. Testing to make sure the voice reader read it correctly was done using [ScreenReader](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn/related) and Chrome, as well as the default Mac Voice Reader and Safari.


### Screenshots

No changes to website visuals, only additional aria-labels

### Checklist:

_Please delete any options that are not relevant_

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings in the console
- [X] There are no new linting errors/problems in my code
- [X] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
