### PR TITLE
Tf 6348/add css selectors get started and why vacate

### DIFF
--- a/pages/get-started.tsx
+++ b/pages/get-started.tsx
@@ -42,6 +42,7 @@ export default function GetStartedPage() {
 
       <SectionContainer>
         <ButtonGroup
+          className="get-started-buttons"
           variant="text"
           fullWidth
           orientation={matchesXS ? 'vertical' : 'horizontal'}
@@ -60,7 +61,7 @@ export default function GetStartedPage() {
         </ButtonGroup>
       </SectionContainer>
 
-      <SectionContainer id="step-1">
+      <SectionContainer id="step-1-documents">
         <GetStartedStep
           title={content.steps[0].title}
           bodyText={content.steps[0].body}
@@ -102,7 +103,7 @@ export default function GetStartedPage() {
         </GetStartedStep>
       </SectionContainer>
 
-      <SectionContainer id="step-2">
+      <SectionContainer id="step-2-eligibility">
         <GetStartedStep
           title={content.steps[1].title}
           bodyText={content.steps[1].body}
@@ -127,7 +128,7 @@ export default function GetStartedPage() {
         </GetStartedStep>
       </SectionContainer>
 
-      <SectionContainer id="step-3">
+      <SectionContainer id="step-3-file-with-court">
         <GetStartedStep
           title={content.steps[2].title}
           bodyText={content.steps[2].body}
@@ -138,7 +139,7 @@ export default function GetStartedPage() {
           <Grid container spacing={8} sx={{ my: 1 }}>
             {content.rejectionReasons.map((fact) => (
               <FactCard
-                className="fact-card"
+                className={`fact-card-${fact.id}`}
                 key={fact.id}
                 icon="none"
                 details={fact.details}
@@ -148,7 +149,7 @@ export default function GetStartedPage() {
         </GetStartedStep>
       </SectionContainer>
 
-      <SectionContainer id="step-4">
+      <SectionContainer id="step-4-court-hearing">
         <GetStartedStep
           title={content.steps[3].title}
           bodyText={content.steps[3].body}

--- a/pages/why-vacate.tsx
+++ b/pages/why-vacate.tsx
@@ -35,8 +35,9 @@ export default function WhyVacatePage() {
         imgsrc={content.heroBanner.imgsrc}
       />
 
-      <SectionContainer>
+      <SectionContainer id="main-section">
         <ButtonGroup
+          id="main-button-group"
           variant="text"
           fullWidth
           orientation={matchesXS ? 'vertical' : 'horizontal'}
@@ -49,7 +50,7 @@ export default function WhyVacatePage() {
         </ButtonGroup>
 
         {content.cards.map((card: any) => (
-          <SectionContainer id={card.sectionId} key={card.sectionId}>
+          <SectionContainer id={`section-${card.sectionId}`} key={card.sectionId}>
             <PaperSection
               title={card.title}
               subtitle={card.subtitle}
@@ -69,7 +70,7 @@ export default function WhyVacatePage() {
                 ))}
 
               </Grid>
-              <Typography variant="h3">{content.resourcesText}</Typography>
+              <Typography id="heading-resources" variant="h3">{content.resourcesText}</Typography>
               <Grid container spacing={2}>
 
                 {card.accordianItems.map((accordianItem: any) => (

--- a/pages/why-vacate.tsx
+++ b/pages/why-vacate.tsx
@@ -35,7 +35,7 @@ export default function WhyVacatePage() {
         imgsrc={content.heroBanner.imgsrc}
       />
 
-      <SectionContainer id="main-section">
+      <SectionContainer id="why-vacate-main">
         <ButtonGroup
           id="main-button-group"
           variant="text"


### PR DESCRIPTION
### Ticket(s)

- [6348](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recO81WnsPRkZf4Y8)

### Type of change

- [x] Design change

### Description

Add CSS selectors to get started, why vacate. The codebase is pretty light on CSS selectors in components that were built as part of the V2 migration to Next.js. Because of this, debugging and finding components in dev-tools can be frustrating and difficult.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
