### PR TITLE
TF-8784/Add workflow cron job to merge staging into main every other week

### DIFF
--- a/.github/workflows/scheduled_merge.yml
+++ b/.github/workflows/scheduled_merge.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'yes'
   schedule:
-    - cron: '0 17 */15 * *'  # execute every 15 days at 17:00 UTC
+    - cron: '0 17 */14 * *'  # execute every 15 days at 17:00 UTC
 
 permissions: write-all
 
@@ -86,7 +86,7 @@ jobs:
 
     - name: Configure user
       run: |
-        git remote set-url origin "https://${{ secrets.PAT_TOKEN }}@github.com/funas-org/cv-tests.git"
+        git remote set-url origin "https://${{ secrets.CV_DEVS_PAT }}@github.com/clearviction-devs/clearviction-wa.git"
 
     - name: Get and Update staging branch
       run: |

--- a/.github/workflows/scheduled_merge.yml
+++ b/.github/workflows/scheduled_merge.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build
         run: npm run build --if-present
         env:
-          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
 
   merge:

--- a/.github/workflows/scheduled_merge.yml
+++ b/.github/workflows/scheduled_merge.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'yes'
   schedule:
-    - cron: '0 17 */14 * *'  # execute every 15 days at 17:00 UTC
+    - cron: '0 17 */14 * *'  # execute every 14 days at 17:00 UTC
 
 permissions: write-all
 

--- a/.github/workflows/scheduled_merge.yml
+++ b/.github/workflows/scheduled_merge.yml
@@ -1,0 +1,114 @@
+name: Schedule Merge Staging into Main
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_job:
+        description: 'Execute manually'
+        required: true
+        default: 'yes'
+  schedule:
+    - cron: '0 17 */15 * *'  # execute every 15 days at 17:00 UTC
+
+permissions: write-all
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Setup node
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: '^18.0.0'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - uses: actions/cache@v3.3.2
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+  lint:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Setup node
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: '^18.0.0'
+          cache: 'npm'
+
+      - uses: actions/cache@v3.3.2
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+
+      - run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Setup node
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: '^18.0.0'
+          cache: 'npm'
+
+      - uses: actions/cache@v3.3.2
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+      
+      - name: Build
+        run: npm run build --if-present
+        env:
+          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4.1.1
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+
+    - name: Configure user
+      run: |
+        git remote set-url origin "https://${{ secrets.PAT_TOKEN }}@github.com/funas-org/cv-tests.git"
+
+    - name: Get and Update staging branch
+      run: |
+        git fetch origin staging
+        git checkout staging
+        git pull origin staging
+        git checkout main
+
+    - name: Merge to Main and Push
+      run: |
+        git merge --ff-only staging
+        git push origin main
+  
+  handle-fail:
+    runs-on: ubuntu-latest
+    needs: [install, lint, build, merge]
+    if: failure()
+    steps:
+    - uses: actions/checkout@v4.1.1
+
+    - name: Check Workflow Status
+      run: gh issue create --title "Failed Merge" --body "Workflow that merge staging to main failed. Please check logs."
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
### Ticket(s)

- [8784](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rec1pUwPFHLipqUm1)

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Description

Add a new workflow that handle `staging into main` process from TF team every other week.

This workflow has some jobs before merging to do some basics verification on code to be merged.

If something fail, a new issue is created to inform that something need to be done.

`IMPORTANT NOTE:` We need to create some env before merge this 

### Screenshots

#### Process on `Success`
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/fbf77360-c025-4a0c-8b32-f66ed8257909)

#### Process on `Fail`
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/82401984-ceea-4a96-a347-a5cf2a7b1e1c)

#### Automated `Issue` created
![image](https://github.com/clearviction-devs/clearviction-wa/assets/80538553/da5a1cb2-bfcd-4ecb-867b-d74d39c1dc22)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
