### PR TITLE
Tf 10293/refactor 3rd party workflow

### DIFF
--- a/.github/workflows/3rd-party-check.yml
+++ b/.github/workflows/3rd-party-check.yml
@@ -90,6 +90,9 @@ jobs:
           COMMENT_BODY+="| **Other options** | What other options have you considered, and why did you choose this package? |   |\n"
           COMMENT_BODY+="| **Can we do it ourselves** | Why is an external solution better than a custom solution of our own? |   |\n"
           COMMENT_BODY+="| **Other notes** | Is there any other information you would like to share? |   |\n\n"
+
+          # Add a unique tag to the comment to identify it later
+          COMMENT_BODY+="<!-- DependencyCheckTag -->\n"
   
           # Post the comment using GitHub API
           curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.github/workflows/3rd-party-check.yml
+++ b/.github/workflows/3rd-party-check.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Post Comment
-        if: steps.dependency_check.outputs.package_json_changed == 'true' || steps.dependency_check.outputs.package_lock_json_changed == 'true'
+        if: (steps.dependency_check.outputs.package_json_changed == 'true' || steps.dependency_check.outputs.package_lock_json_changed == 'true') && steps.check_comment.outputs.comment_already_posted == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/3rd-party-check.yml
+++ b/.github/workflows/3rd-party-check.yml
@@ -48,6 +48,25 @@ jobs:
           echo "package_json_changed=$PACKAGE_JSON_CHANGED" >> $GITHUB_OUTPUT
           echo "package_lock_json_changed=$PACKAGE_LOCK_JSON_CHANGED" >> $GITHUB_OUTPUT
 
+      - name: Check if Comment Already Posted
+        id: check_comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          COMMENTS_URL="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+          COMMENT_TAG="<!-- DependencyCheckTag -->"
+  
+          # Fetch comments
+          COMMENTS=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$COMMENTS_URL")
+  
+          # Check if our unique tag is already in the comments
+          if echo "$COMMENTS" | grep -q "$COMMENT_TAG"; then
+            echo "comment_already_posted=true" >> $GITHUB_OUTPUT
+          else
+            echo "comment_already_posted=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Post Comment
         if: steps.dependency_check.outputs.package_json_changed == 'true' || steps.dependency_check.outputs.package_lock_json_changed == 'true'
         env:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,11 +68,16 @@ This GitHub Actions workflow is designed to automatically scrutinize pull reques
     - checks for changes in `package.json` or `package-lock.json`
     - sets the flags `PACKAGE_JSON_CHANGED` and `PACKAGE_LOCK_JSON_CHANGED` to `true` if changes are detected in respective files
     - these flags are then written to the `$GITHUB_OUTPUT` variable to be used by subsequent steps
+1. **Check if Comment Already Posted**
+    - Fetches all existing comments from the pull request using the GitHub API
+    - Searches these comments for a unique tag `<!-- DependencyCheckTag -->`. This tag is used to identify if the automated comment has already been posted
+    - If the tag is found, it sets a flag `comment_already_posted=true` to prevent reposting. Otherwise, it sets `comment_already_posted=false`
 1. **Post comment with form**
-    - this step is conditional and only executes if changes are detected in either of the specified files
+    - This step is conditional and only executes if changes are detected in either of the specified files and the comment has not already been posted (`comment_already_posted=false`)
     - constructs a detailed comment body asking the pull request author to justify the inclusion of new third party dependencies
     - uses the GitHub API to post this comment on the pull request, and tags the author, thus ensuring the author is aware of the need to provide the necessary justification
     - the comment includes a structured form with specific questions and considerations regarding the new dependencies
+    - To prevent duplicate comments on subsequent pushes to the same PR, the comment includes a unique tag `<!-- DependencyCheckTag -->` at the end
 
 ## Merge Staging -> Main Cron Job
 This workflow merges the `staging` branch into `main` every other Tuesday. This is a process that is necessary to update the production website with new changes from development/the staging branch. Some basic verifications are done before the merge process to ensure that this can be completed successfully, and if something goes wrong, an issue is created to inform that the process failed.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,15 +69,15 @@ This GitHub Actions workflow is designed to automatically scrutinize pull reques
     - sets the flags `PACKAGE_JSON_CHANGED` and `PACKAGE_LOCK_JSON_CHANGED` to `true` if changes are detected in respective files
     - these flags are then written to the `$GITHUB_OUTPUT` variable to be used by subsequent steps
 1. **Check if Comment Already Posted**
-    - Fetches all existing comments from the pull request using the GitHub API
-    - Searches these comments for a unique tag `<!-- DependencyCheckTag -->`. This tag is used to identify if the automated comment has already been posted
-    - If the tag is found, it sets a flag `comment_already_posted=true` to prevent reposting. Otherwise, it sets `comment_already_posted=false`
+    - fetches all existing comments from the pull request using the GitHub API
+    - searches these comments for a unique tag `<!-- DependencyCheckTag -->`. This tag is used to identify if the automated comment has already been posted
+    - if the tag is found, it sets a flag `comment_already_posted=true` to prevent reposting. Otherwise, it sets `comment_already_posted=false`
 1. **Post comment with form**
-    - This step is conditional and only executes if changes are detected in either of the specified files and the comment has not already been posted (`comment_already_posted=false`)
+    - this step is conditional and only executes if changes are detected in either of the specified files and the comment has not already been posted (`comment_already_posted=false`)
     - constructs a detailed comment body asking the pull request author to justify the inclusion of new third party dependencies
     - uses the GitHub API to post this comment on the pull request, and tags the author, thus ensuring the author is aware of the need to provide the necessary justification
     - the comment includes a structured form with specific questions and considerations regarding the new dependencies
-    - To prevent duplicate comments on subsequent pushes to the same PR, the comment includes a unique tag `<!-- DependencyCheckTag -->` at the end
+    - to prevent duplicate comments on subsequent pushes to the same PR, the comment includes a unique tag `<!-- DependencyCheckTag -->` at the end
 
 ## Merge Staging -> Main Cron Job
 This workflow merges the `staging` branch into `main` every other Tuesday. This is a process that is necessary to update the production website with new changes from development/the staging branch. Some basic verifications are done before the merge process to ensure that this can be completed successfully, and if something goes wrong, an issue is created to inform that the process failed.


### PR DESCRIPTION
### Ticket(s)

_Required unless this is just a change to documentation._

- [10293](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rec6E6oA7jDcAh5sS)

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation or testing

### Description

- Currently our `New 3rd Party Dependency Check` workflow has a bug where it keeps commenting the justification form every time a new commit is pushed to a PR that includes changes to the `package.json` or `package-lock.json` files. 
- I have resolved this issue in the following ways:

  -  I have added a step that checks the comment history of the PR and looks for a comment with `<!-- DependencyCheckTag -->` tag. This will determine whether the form is posted as a comment on the PR
  - In the post comment step, I have refactored the conditional to check if `comment_already_posted` is `false`
  
    - the `Post Comment` step also now adds the `DependencyCheckTag` to the comment body

### Screenshots

no relevant screenshots

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings in the console
- [X] There are no new linting errors/problems in my code
- [X] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
