### PR TITLE
Add CSS Selectors to index

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -37,7 +37,7 @@ export default function Home() {
 
         <HeroBanner {...content.heroBanner} aria-label={content.heroBanner.ariaLabels?.ctaButton} />
 
-        <SectionContainer id="button-group">
+        <SectionContainer id="home-nav-section">
           <ButtonGroup
             variant="text"
             fullWidth

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -37,7 +37,7 @@ export default function Home() {
 
         <HeroBanner {...content.heroBanner} aria-label={content.heroBanner.ariaLabels?.ctaButton} />
 
-        <SectionContainer>
+        <SectionContainer id="button-group">
           <ButtonGroup
             variant="text"
             fullWidth
@@ -53,7 +53,7 @@ export default function Home() {
 
         <SectionContainer id={content.ourMission.id}>
           <PaperSection>
-            <Grid container>
+            <Grid container id={`${content.ourMission.id}-main-grid`}>
               <Grid item xs={12}>
                 <Typography variant="h2" sx={{ textAlign: 'center' }}>
                   {content.ourMission.header}
@@ -97,7 +97,7 @@ export default function Home() {
               ctaText={section.ctaText}
               ariaLabels={{ ctaButton: section.ariaLabels?.ctaButton }}
             >
-              <Grid container spacing={4}>
+              <Grid container spacing={4} id={`${section.id}-main-grid`}>
                 {section.items.map((item) => (
                   <GridItemCard
                     key={item.id}


### PR DESCRIPTION
### Ticket(s)

- [6350](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recmZXm8MZXok1Xt6)

### Type of change

_Please delete any options that are not relevant_

- [ ] Design change

### Description

Add CSS selectors to index. The codebase is pretty light on CSS selectors in components that were built as part of the V2 migration to Next.js. Because of this, debugging and finding components in dev-tools can be frustrating and difficult.

### Screenshots

NA

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
