### PR TITLE
Add PR checklist from docs to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,51 @@ _Include relevant screenshots_
 
 #### After
 
-### Checklist:
+### Review your work
+Please self review your work before requesting further review. _Wait until you reach the next screen to check off the boxes._
+
+#### Preview
+
+- [ ] Pull down the branch and run the code locally or use Preview build
+- [ ] Everything works as expected
+- [ ] Check changed page(s)
+- [ ] Click through calculator if changes were made
+- [ ] Compare figma screenshot with the changes
+- [ ] Compare linked Figma section to changes made
+- [ ] Refresh the page, check that using the go-back button works as expected
+- [ ] Check large screen size (>1400)
+- [ ] Check tablet screen size (<786)
+- [ ] Check mobile screen size (<375)
+- [ ] Check that links work
+- [ ] Check the console for errors or warnings
+- [ ] Check the terminal for any errors or problems
+- [ ] Check for any uncaught ESLint problems
+
+#### Code Clarity and Readability
+- [ ] Are variable and function names descriptive, meaningful, in the appropriate case (ex: snake, camel)?
+- [ ] Is the code self-explanatory and easy to understand?
+- [ ] Are comments used where necessary to explain complex logic or provide additional context?
+
+#### Code Efficiency
+- [ ] Is the code DRY?
+- [ ] Are there any areas of unnecessary complexity or duplication that might benefit from refactoring?
+
+#### Code Modularity and Reusability
+- [ ] Is the code and any new components organized in a logical location in the directory?
+- [ ] Can any code snippets be refactored into reusable components?
+- [ ] Are there opportunities to abstract common functionality into separate functions or classes?
+- [ ] Is there good use of CSS selectors when creating new components or refactoring old ones?
+
+#### Best Practices and Coding Standards
+- [ ] Does the code follow the established coding standards and style guide of the project?
+- [ ] Are there any violations of best practices that should be addressed?
+- [ ] Are there any hard-coded strings or UI elements that should be externalized?
+- [ ] Are all measurement units in REM? (border-radius, borders should still be in px)
+- [ ] Is there any unnecessary commented out code lingering?
+- [ ] Are all files TypeScript?
+
+
+### Overall PR Checklist:
 
 _Please delete any options that are not relevant_
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,8 +34,8 @@ _Include relevant screenshots_
 Please self review your work before requesting further review. _Wait until you reach the next screen to check off the boxes._
 
 #### Preview
+Use your local or the preview build.
 
-- [ ] Pull down the branch and run the code locally or use Preview build
 - [ ] Everything works as expected
 - [ ] Check changed page(s)
 - [ ] Click through calculator if changes were made
@@ -84,4 +84,5 @@ _Please delete any options that are not relevant_
 - [ ] My changes generate no new warnings in the console
 - [ ] There are no new linting errors/problems in my code
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
+- [ ] I have filled out the new 3rd party dependency checklist (if applicable)
 - [ ] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ _Include relevant screenshots_
 Please self review your work before requesting further review. _Wait until you reach the next screen to check off the boxes._
 
 #### Preview
-Use your local or the preview build.
+Use your local.
 
 - [ ] Everything works as expected
 - [ ] Check changed page(s)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ _Include relevant screenshots_
 Please self review your work before requesting further review. _Wait until you reach the next screen to check off the boxes._
 
 #### Preview
-Use your local.
+Use your local build.
 
 - [ ] Everything works as expected
 - [ ] Check changed page(s)


### PR DESCRIPTION
### Ticket(s)

- _[10668](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recapYBo2MiP1aVbs)_

### Type of change

- [x] Documentation or testing

### Description

Adds the PR review guide checklist to the PR template so that contributors can self-review according to the terms we review them on, hopefully decreasing further changes needing to be requested.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
