### PR TITLE
Use groups to contain dependabot updates into group PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,20 +10,20 @@ updates:
     schedule:
       interval: "weekly"
 
-# this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
-groups:
-  dev:
-    dependency-type: "development"
-    update-types:
-    - "minor"
-    - "major"
+    # this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
+    groups:
+      dev:
+        dependency-type: "development"
+        update-types:
+        - "minor"
+        - "major"
 
-  prod:
-    dependency-type: "production"
-    update-types:
-    - "minor"
-    - "major"
-    
-ignore:
-  - dependency-name: "next"
-    update-types: ["version-update:semver-major"]
+      prod:
+        dependency-type: "production"
+        update-types:
+        - "minor"
+        - "major"
+        
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,25 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/" 
     schedule:
       interval: "weekly"
+
+# this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
+groups:
+  dev:
+    dependency-type: "development"
+    update-types:
+    - "minor"
+    - "major"
+
+  prod:
+    dependency-type: "production"
+    update-types:
+    - "minor"
+    - "major"
+    
+ignore:
+  - dependency-name: "next"
+    update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Ticket(s)

- _[11842](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rectX5fdhaDRHmKSd)_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Updates the `dependabot.yml` with further consideration of our actual needs from dependabot. Using groups, dependabot will open one pull request on behalf of all dependencies in that group. I separated them into prod dependencies and dev dependencies, and allow for only major and minor update types, omitting patch. I further ignored all major version updates specifically for next, since we want to control when that happens separately.

### Overall PR Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
