### PR TITLE
Include patch updates in group update PR, add next-sanity to ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,16 +14,10 @@ updates:
     groups:
       dev:
         dependency-type: "development"
-        update-types:
-        - "minor"
-        - "major"
 
       prod:
         dependency-type: "production"
-        update-types:
-        - "minor"
-        - "major"
         
     ignore:
-      - dependency-name: "next"
+      - dependency-name: "next, next-sanity"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Ticket(s)

- _[11842](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rectX5fdhaDRHmKSd)_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Updates the `dependabot.yml` again, adding the patches to the group PRs. Previously I had meant to just not include the patch updates but when an update it not caught by a group it just opens it's own PR which is not what I had intended. Since the PR now includes all of the updates together I think it is okay to leave them in.

### Overall PR Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
