### PR TITLE
prep felony calc changes by implementing test copy of head

### DIFF
--- a/components/calculator/misdemeanor/CalcHeader.tsx
+++ b/components/calculator/misdemeanor/CalcHeader.tsx
@@ -12,7 +12,7 @@ export default function CalcHeader({ page, isFirstPage }:
   const router = useRouter();
 
   const isPageIncludedInStepper = () => {
-    const excludedPageSlug = 'head';
+    const excludedPageSlug = 'test';
     const isPartOfHead = page.slug.includes(excludedPageSlug);
     const { isFinalPage } = page;
     return !(isFinalPage || isPartOfHead);

--- a/components/calculator/misdemeanor/QandAContainer.tsx
+++ b/components/calculator/misdemeanor/QandAContainer.tsx
@@ -17,6 +17,16 @@ export default function QandAContainer({
     isFinalPage: page.isFinalPage,
   }), [page.isFinalPage]);
 
+  const linkToPage = (choice) => {
+    if (choice.linkTo) {
+      return `/calculator/${choice.linkTo.slug.current}`;
+    }
+    if (choice.linkToOtherPageType) {
+      return `/calculator/${choice.linkToOtherPageType.slug.current}`;
+    }
+    return '#';
+  };
+
   return (
     <>
       <PageContext.Provider value={contextValue}>
@@ -37,9 +47,7 @@ export default function QandAContainer({
 
           {page.choices
             && page.choices.map((choice) => {
-              const linkTo = choice.linkTo
-                ? `/calculator/${choice.linkTo.slug.current}`
-                : '#';
+              const linkTo = linkToPage(choice);
               const href = choice.isExternalLink ? choice.url : linkTo;
               return (
                 <Button

--- a/components/helper/ShareButtons.tsx
+++ b/components/helper/ShareButtons.tsx
@@ -17,7 +17,7 @@ type ShareButtonsProps = {
   shareLinkCopied: boolean;
 };
 
-const CALCULATOR_URL = 'https://clearviction.org/calculator/head-initial-1-cont';
+const CALCULATOR_URL = 'https://clearviction.org/calculator/test-initial-1-cont';
 
 const socialMediaTextStyles = {
   fontWeight: 400,

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -86,7 +86,7 @@ export default function Header() {
             }}
           >
             <Button
-              href="/calculator/head-initial-1-cont"
+              href="/calculator/test-initial-1-cont"
               variant="contained"
               color="neutral"
               size="small"

--- a/content/about.ts
+++ b/content/about.ts
@@ -64,7 +64,7 @@ const aboutContent: AboutContent = {
     body: 'While the project started in Seattle, we now have volunteers all across the country and the world dedicating time outside of full-time jobs, graduate programs, and busy lives, to help folks clear their criminal records - giving them a fighting chance to escape a life full of poverty, homelessness, and recidivism.',
   },
   body: [
-    'To support this mission, we have started by creating a [Conviction Eligibility Calculator](https://clearviction.org/calculator/head-initial-1-cont), getting people started down the path of clearing their convictions and starting their life again. The process of vacating a conviction is very convoluted, making it difficult to navigate:',
+    'To support this mission, we have started by creating a [Conviction Eligibility Calculator](https://clearviction.org/calculator/test-initial-1-cont), getting people started down the path of clearing their convictions and starting their life again. The process of vacating a conviction is very convoluted, making it difficult to navigate:',
   ],
   facts: [
     {

--- a/content/get-started.ts
+++ b/content/get-started.ts
@@ -56,7 +56,7 @@ const getStartedContent: GetStartedContent = {
     {
       title: 'Step 2: Check Your Eligibility',
       body: 'Once you have your records and forms gathered, use our eligibility calculator to determine whether you are eligible to vacate your misdemeanor conviction. It is expected to take 10-30 minutes.',
-      ctaLink: '/calculator/head-initial-1-cont',
+      ctaLink: '/calculator/test-initial-1-cont',
       ctaText: 'Access Calculator',
       ariaLabels: { ctaButton: 'Access our eligibility calculator' },
       data: [],

--- a/content/home.ts
+++ b/content/home.ts
@@ -19,7 +19,7 @@ const content: HomeContent = {
   heroBanner: {
     header: 'Check your eligibility to vacate a Washington State conviction',
     subheading: 'Our free eligibility calculator can check if your conviction qualifies for vacation in less than 10 minutes.',
-    ctaLink: '/calculator/head-initial-1-cont',
+    ctaLink: '/calculator/test-initial-1-cont',
     ctaText: 'Access Calculator',
     imgsrc: '/illustrations/home-hero-2color.svg',
     ariaLabels: { ctaButton: 'Access our eligibility calculator' },

--- a/content/navItems.ts
+++ b/content/navItems.ts
@@ -30,7 +30,7 @@ const navItems: NavItem[] = [
     text: 'Contact',
   },
   {
-    href: '/calculator/head-initial-1-cont',
+    href: '/calculator/test-initial-1-cont',
     text: 'Access Calculator',
   },
 ];

--- a/pages/calculator/[slug].tsx
+++ b/pages/calculator/[slug].tsx
@@ -17,9 +17,9 @@ import IndividualPageHead from '../../components/helper/IndividualPageHead.tsx';
 import Results from '../../components/helper/Results.tsx';
 import { StaticCalcProps } from '../../utils/calculator.props.ts';
 import {
+  getAllPagePaths,
+  getAllPagesBySlug,
   getCalculatorConfig,
-  getMisdemeanorPageBySlug,
-  getMisdemeanorPagePaths,
 } from '../../utils/sanity.client.ts';
 
 export default function CalculatorSlugRoute({ page, calculatorConfig }: StaticCalcProps) {
@@ -29,13 +29,13 @@ export default function CalculatorSlugRoute({ page, calculatorConfig }: StaticCa
   const [responseObject, setResponseObject] = useState({});
   const [showResults, setShowResults] = useState(false);
 
-  const calcFirstPageUrl = 'https://clearviction.org/calculator/head-initial-1-cont';
-  const isFirstPage = () => page.slug === 'head-initial-1-cont';
+  const calcFirstPageUrl = 'https://clearviction.org/calculator/test-initial-1-cont';
+  const isFirstPage = () => page.slug === 'test-initial-1-cont';
   const contentRef = useRef<HTMLDivElement>(null);
 
   const addToResponses = (answer: string) => {
     // delete object when start over
-    if (page.slug === 'head-initial-1-cont') setResponseObject({});
+    if (page.slug === 'test-initial-1-cont') setResponseObject({});
     if (
       answer !== 'Continue'
       && answer !== 'Next'
@@ -166,7 +166,7 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   const slug = params.slug as string || '';
 
   const [page, calculatorConfig] = await Promise.all([
-    getMisdemeanorPageBySlug({ slug }),
+    getAllPagesBySlug({ slug }),
     getCalculatorConfig(),
   ]);
 
@@ -185,7 +185,7 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = await getMisdemeanorPagePaths();
+  const paths = await getAllPagePaths();
 
   return {
     paths: paths?.map((slug) => `/calculator/${slug}`) || [],

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -30,7 +30,7 @@
       <lastmod>2023-08-08</lastmod>
     </url>
     <url>
-      <loc>http://www.clearviction.org/calculator/head-initial-1-cont</loc>
+      <loc>http://www.clearviction.org/calculator/test-initial-1-cont</loc>
       <lastmod>2023-08-08</lastmod>
     </url>
   </urlset>

--- a/utils/sanity.client.ts
+++ b/utils/sanity.client.ts
@@ -26,34 +26,42 @@ interface CalcPageBySlugParams {
 // `calculatorInfoPage` is the id/name of the Sanity MISDEMEANOR page however,
 // the visual "title" for Sanity Studio is "Calculator Misdemeanor Page"
 
-export async function getMisdemeanorPageBySlug({ slug, token }: CalcPageBySlugParams) {
-  return sanityClient(token)?.fetch(
-    basePagesBySlugQuery,
-    { slug, pageType: 'calculatorInfoPage' },
-  );
-}
+// export async function getMisdemeanorPageBySlug({ slug, token }: CalcPageBySlugParams) {
+//   return sanityClient(token)?.fetch(
+//     basePagesBySlugQuery,
+//     { slug, pageType: 'calculatorInfoPage' },
+//   );
+// }
 
-export async function getMisdemeanorPagePaths(): Promise<string[] | undefined> {
-  return sanityClient()?.fetch(
-    basePagePathsQuery,
-    { pageType: 'calculatorInfoPage' },
-  );
-}
+// export async function getMisdemeanorPagePaths(): Promise<string[] | undefined> {
+//   return sanityClient()?.fetch(
+//     basePagePathsQuery,
+//     { pageType: 'calculatorInfoPage' },
+//   );
+// }
 
-export async function getFelonyPageBySlug({ slug, token }: CalcPageBySlugParams) {
-  return sanityClient(token)?.fetch(
-    basePagesBySlugQuery,
-    { slug, pageType: 'calculatorFelonyPage' },
-  );
-}
+// export async function getFelonyPageBySlug({ slug, token }: CalcPageBySlugParams) {
+//   return sanityClient(token)?.fetch(
+//     basePagesBySlugQuery,
+//     { slug, pageType: 'calculatorFelonyPage' },
+//   );
+// }
 
-export async function getFelonyPagePaths(): Promise<string[] | undefined> {
-  return sanityClient()?.fetch(
-    basePagePathsQuery,
-    { pageType: 'calculatorFelonyPage' },
-  );
-}
+// export async function getFelonyPagePaths(): Promise<string[] | undefined> {
+//   return sanityClient()?.fetch(
+//     basePagePathsQuery,
+//     { pageType: 'calculatorFelonyPage' },
+//   );
+// }
 
 export async function getCalculatorConfig() {
   return sanityClient()?.fetch(calculatorConfigQuery);
+}
+
+export async function getAllPagesBySlug({ slug, token }: CalcPageBySlugParams) {
+  return sanityClient(token)?.fetch(basePagesBySlugQuery, { slug });
+}
+
+export async function getAllPagePaths(): Promise<string[] | undefined> {
+  return sanityClient()?.fetch(basePagePathsQuery);
 }

--- a/utils/sanity.queries.ts
+++ b/utils/sanity.queries.ts
@@ -1,11 +1,11 @@
 import { groq } from 'next-sanity';
 
 export const basePagePathsQuery = groq`
-  *[_type == $pageType && slug.current != null].slug.current
+  *[slug.current != null].slug.current
 `;
 
 export const basePagesBySlugQuery = groq`
-*[_type == $pageType && slug.current == $slug][0] {
+*[slug.current == $slug][0] {
   _id,
   title,
   content,
@@ -13,7 +13,7 @@ export const basePagesBySlugQuery = groq`
   isFinalPage,
   isEligible,
   isUndetermined,
-  "choices": choices[]{_key, url, isExternalLink, label, linkTo->{slug}},
+  "choices": choices[]{_key, url, isExternalLink, label, linkTo->{slug}, linkToOtherPageType->{slug}},
   "slug": slug.current,
 }
 `;


### PR DESCRIPTION
Implementing initial changes that will allow everyone else to work on their tasks and test their changes. All of these changes should NOT be merged to staging until next steps are completed.

1. created branch scrum53-felony-calc as our dev branch for the felony implementation. other branches should be created off of this.
2. created a working branch off of the above dev branch
3. created test versions of the first 3 "head" pages, and subbed in "test" for "head"
4. in the repo, search and replaced all mentions of "head-initial-1-cont" (calc start page) with "test-initial-1-cont"
5. in the CalcHeader component, changed 'head' to 'test' on the line that keeps the progress bar off of the initial head of the calculator
6. in sanity.queries.ts i removed the page type parameter so that we can query the page information without specifying and separating misdemeanor from felony
7. in sanity.client.ts instead of using separate funcs for mis and felony, i created a single handler for page paths and a single handler for page info and then updated the calculator/slug.ts to use the single grouped queries
8. in the Q and A calc component, I created a new function for LinkTo to allow misdemeanor and felony pages to link to each other based on the newly added field linkToOtherPageType


Next steps:

- Mindy and Stephan work on their tasks
- open a PR from scrum53-felony-calc to staging for a dev preview for QA purposes
- when ready for actual launch, revert # 4 and # 5, delete test pages in # 3, and align head-mis-3-cont with the new version of it, which links everything together
- delete the undetermined page, and can also delete this from sanity calc config schema, since it only applied to someone answering NO this is not a misdemeanor, its a felony.