### PR TITLE
TF 12100/add major version updates of MUI to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,13 @@ updates:
 
       prod:
         dependency-type: "production"
+
+      
         
     ignore:
       - dependency-name: "next"
         update-types: ["version-update:semver-major"]
       - dependency-name: "next-sanity"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@mui/*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Ticket(s)

- _[12100](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recrj7x6p4nQGR1Th)_

### Type of change

- [x] Configuration changes

### Description

Dependencies matching `@mui/*` with major version updates are ignored by dependabot version updates.

### Overall PR Checklist:

- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
