### PR TITLE
remove undetermined feedback url and isDetermined field from page

### DIFF
--- a/components/calculator/CTAContainers.tsx
+++ b/components/calculator/CTAContainers.tsx
@@ -26,7 +26,9 @@ function CheckAnotherConviction({ calculatorConfig }: {
   );
 }
 
-function FeedbackContainer({ calculatorConfig }: StaticCalcProps) {
+function FeedbackContainer({ calculatorConfig }: {
+  calculatorConfig: StaticCalcProps['calculatorConfig']
+}) {
   return (
     <Button
       data-cy="feedback-button"
@@ -108,8 +110,9 @@ export function ErrorReportContainer({ calculatorConfig }: {
 }
 
 export default function FinalPageLinksContainer({
-  page, calculatorConfig, setOpenSharePopup, calcFirstPageUrl,
-}: StaticCalcProps &{
+  calculatorConfig, setOpenSharePopup, calcFirstPageUrl,
+}: {
+    calculatorConfig: StaticCalcProps['calculatorConfig'],
     setOpenSharePopup: SharedCalcProps['setOpenSharePopup'],
     calcFirstPageUrl: SharedCalcProps['calcFirstPageUrl'],
   }) {
@@ -128,7 +131,8 @@ export default function FinalPageLinksContainer({
         gap: 2,
       }}
     >
-      <FeedbackContainer page={page} calculatorConfig={calculatorConfig} />
+      <FeedbackContainer calculatorConfig={calculatorConfig} />
+
       <Box>
         <CheckAnotherConviction calculatorConfig={calculatorConfig} />
         <ShareCalcContainer

--- a/components/calculator/CTAContainers.tsx
+++ b/components/calculator/CTAContainers.tsx
@@ -26,16 +26,12 @@ function CheckAnotherConviction({ calculatorConfig }: {
   );
 }
 
-function FeedbackContainer({ page, calculatorConfig }: StaticCalcProps) {
+function FeedbackContainer({ calculatorConfig }: StaticCalcProps) {
   return (
     <Button
       data-cy="feedback-button"
       variant="contained"
-      href={
-          page.isUndetermined
-            ? calculatorConfig.feedback.isUndeterminedUrl
-            : calculatorConfig.feedback.allOtherFeedbackUrl
-              }
+      href={calculatorConfig.feedback.feedbackUrl}
       sx={{ ml: 0, mr: 0 }}
     >
       {calculatorConfig.feedback.linkText}

--- a/pages/calculator/[slug].tsx
+++ b/pages/calculator/[slug].tsx
@@ -93,7 +93,6 @@ export default function CalculatorSlugRoute({ page, calculatorConfig }: StaticCa
           (page.isFinalPage) && (
             <>
               <FinalPageLinksContainer
-                page={page}
                 calculatorConfig={calculatorConfig}
                 setOpenSharePopup={setOpenSharePopup}
                 calcFirstPageUrl={calcFirstPageUrl}

--- a/utils/calculator.props.ts
+++ b/utils/calculator.props.ts
@@ -14,6 +14,11 @@ export interface StaticCalcProps {
             current: string;
           };
         };
+        linkToOtherPageType: {
+          slug: {
+            current: string;
+          };
+        };
         isExternalLink: boolean;
         url: string;
       }[];

--- a/utils/calculator.props.ts
+++ b/utils/calculator.props.ts
@@ -20,14 +20,12 @@ export interface StaticCalcProps {
       isQuestion: boolean;
       isFinalPage: boolean;
       isEligible: boolean;
-      isUndetermined: boolean;
     };
     calculatorConfig: {
       legalDisclaimer: string;
       feedback: {
         linkText: string;
-        allOtherFeedbackUrl: string;
-        isUndeterminedUrl: string;
+        feedbackUrl: string;
       };
       checkAnotherConviction: {
         linkText: string;

--- a/utils/sanity.queries.ts
+++ b/utils/sanity.queries.ts
@@ -12,7 +12,6 @@ export const basePagesBySlugQuery = groq`
   isQuestion,
   isFinalPage,
   isEligible,
-  isUndetermined,
   "choices": choices[]{_key, url, isExternalLink, label, linkTo->{slug}, linkToOtherPageType->{slug}},
   "slug": slug.current,
 }


### PR DESCRIPTION
### Ticket(s)

- _[12582](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=rec0OQP5EOkol7cgS)_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

When the calculator was live with only the misdemeanor branch, we had a "undetermined eligibility" boolean flag in sanity, as well as a feedback form url for folks who landed on this page, when clicking that their conviction was NOT a misdemeanor. Now that the felony calculator is live we no longer need this.

**NOTE:** the tests pass locally, but not here on the PR. This is because the PR is using an old Sanity build and locally we are using the most recent sanity changes. 

This PR corresponds to [cv-devs/cv-sanity PR #45](https://github.com/clearviction-devs/clearviction-sanity/pull/45)

### Review your work
Please self review your work before requesting further review. _Wait until you reach the next screen to check off the boxes._

#### Preview
Use your local build.

- [x] Everything works as expected
- [x] Check changed page(s)
- [x] Click through calculator if changes were made
- [x] Compare figma screenshot with the changes
- [x] Compare linked Figma section to changes made
- [x] Refresh the page, check that using the go-back button works as expected
- [x] Check large screen size (>1400)
- [x] Check tablet screen size (<786)
- [x] Check mobile screen size (<375)
- [x] Check that links work
- [x] Check the console for errors or warnings
- [x] Check the terminal for any errors or problems
- [x] Check for any uncaught ESLint problems

### Overall PR Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
