### PR TITLE
Add eslint major version update to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,5 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@mui/*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Type of change

- [x] Documentation or testing

### Description

The new major version update of `eslint` to `v9.0.0` brings many breaking changes, according to [the docs](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/). This will require a migration and some changes on our part, but we also need to wait for `eslint-airbnb-config` to make the update to v9 as well because right now the conflicting peer dependencies are causing a failure in the install step.

This adds `eslint` to the dependabot ignore array so that we can do this on our own time.

### Overall PR Checklist:

- [x] I have performed a self-review of my own code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
