### PR TITLE
replace meta og:image with copy in repo vs AWS bucket

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -40,7 +40,7 @@ export default class MyDocument extends Document {
           <meta
             name="image"
             property="og:image"
-            content="https://cvp-team-photos.s3.us-west-2.amazonaws.com/Calculator_Two+Color+2..svg"
+            content="https://clearviction.org/illustrations/home-hero-2color.svg"
           />
           <meta name="theme-color" content="#000000" />
           <meta


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

When cleaning out our AWS account, I had deleted all of the unused buckets. It seems that we were using one single image in a bucket for our meta tag `og:image`, which I replaced with the equivalent version that already exists in the repo, on our homepage.

### Overall PR Checklist:

- [x] I have performed a self-review of my own code
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand
