### PR TITLE
calculator & home page fixes

### DIFF
--- a/components/calculator/PopupContainers.tsx
+++ b/components/calculator/PopupContainers.tsx
@@ -5,6 +5,7 @@ import {
 import { PortableText } from '@portabletext/react';
 import React from 'react';
 
+import theme from '../../styles/themes/theme.tsx';
 import StaticCalcProps from '../../utils/calculator.props.ts';
 import portableTextComponent from '../../utils/portableTextComponents.tsx';
 
@@ -26,6 +27,7 @@ export default function NotSurePopup({ calculatorConfig, openNotSurePopup, setOp
         sx={{
           backgroundColor: 'secondary.dark',
           color: 'text.light',
+          fontFamily: theme.typography.h3.fontFamily,
         }}
       >
         {calculatorConfig.notSureAnswer.header}

--- a/components/calculator/PopupContainers.tsx
+++ b/components/calculator/PopupContainers.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Dialog, DialogActions, DialogContent, DialogTitle,
 } from '@mui/material';
 import { PortableText } from '@portabletext/react';
@@ -8,6 +7,7 @@ import React from 'react';
 import theme from '../../styles/themes/theme.tsx';
 import StaticCalcProps from '../../utils/calculator.props.ts';
 import portableTextComponent from '../../utils/portableTextComponents.tsx';
+import { CalculatorButton } from '../helper/CustomButtons.tsx';
 
 export default function NotSurePopup({ calculatorConfig, openNotSurePopup, setOpenNotSurePopup }: {
     calculatorConfig: StaticCalcProps['calculatorConfig'],
@@ -21,6 +21,11 @@ export default function NotSurePopup({ calculatorConfig, openNotSurePopup, setOp
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
       data-cy="not-sure-popup"
+      sx={{
+        width: '312px',
+        minHeight: '394px',
+        margin: 'auto',
+      }}
     >
       <DialogTitle
         id="alert-dialog-title"
@@ -28,6 +33,7 @@ export default function NotSurePopup({ calculatorConfig, openNotSurePopup, setOp
           backgroundColor: 'secondary.dark',
           color: 'text.light',
           fontFamily: theme.typography.h3.fontFamily,
+          fontWeight: 600,
         }}
       >
         {calculatorConfig.notSureAnswer.header}
@@ -47,9 +53,9 @@ export default function NotSurePopup({ calculatorConfig, openNotSurePopup, setOp
         color: 'text.light',
       }}
       >
-        <Button onClick={() => setOpenNotSurePopup(false)} data-cy="not-sure-pop-up-close" sx={{ backgroundColor: 'secondary.dark' }}>
+        <CalculatorButton handleClick={() => setOpenNotSurePopup(false)} data-cy="not-sure-pop-up-close">
           {calculatorConfig.notSureAnswer.closeText}
-        </Button>
+        </CalculatorButton>
       </DialogActions>
     </Dialog>
   );

--- a/components/calculator/QandAContainer.tsx
+++ b/components/calculator/QandAContainer.tsx
@@ -85,7 +85,8 @@ export default function QandAContainer({
             pl: 0,
             display: 'flex',
             flexDirection: 'column',
-
+            position: isPartOfHead ? 'static' : 'absolute',
+            top: '536px',
           }}
         >
 

--- a/components/calculator/QandAContainer.tsx
+++ b/components/calculator/QandAContainer.tsx
@@ -76,10 +76,7 @@ export default function QandAContainer({
           id="choices-container"
           disableGutters
           sx={{
-            width: {
-              xs: '100%',
-              sm: '360px',
-            },
+            width: '344px',
             mt: 2,
             mx: 0,
             pl: 0,
@@ -98,11 +95,8 @@ export default function QandAContainer({
               aria-label="Choice options"
               direction={useColumnForChoices ? 'column' : 'row'}
               sx={{
-                justifyContent: {
-                  xs: 'space-between',
-                  sm: 'normal',
-                },
-                pl: 0,
+                width: '312px',
+                justifyContent: 'space-between',
               }}
             >
               {page.choices

--- a/components/calculator/QandAContainer.tsx
+++ b/components/calculator/QandAContainer.tsx
@@ -82,7 +82,7 @@ export default function QandAContainer({
             pl: 0,
             display: 'flex',
             flexDirection: 'column',
-            position: isPartOfHead ? 'static' : 'absolute',
+            position: (isPartOfHead || page.slug === 'm-offense-mari-1-cont') ? 'static' : 'absolute',
             top: '536px',
           }}
         >

--- a/components/calculator/RCWLinkInfo.tsx
+++ b/components/calculator/RCWLinkInfo.tsx
@@ -21,7 +21,7 @@ export default function RCWLinkInfo() {
     <>
       <Box
         padding="32px 0px"
-        minHeight="108px"
+        minHeight="124px"
         sx={{
           display: 'flex',
           gap: '8px',
@@ -46,7 +46,7 @@ export default function RCWLinkInfo() {
 
         {infoPopup && (
           <Box>
-            <Typography variant="body2" sx={{ color: 'black', display: 'inline' }}>
+            <Typography variant="body2" sx={{ color: theme.palette.text.primary, display: 'inline' }}>
               Throughout the calculator, you may need to view the
               {' '}
             </Typography>
@@ -64,7 +64,7 @@ export default function RCWLinkInfo() {
             >
               RCW links
             </Typography>
-            <Typography variant="body2" sx={{ color: 'black', display: 'inline' }}> provided for each question to determine your answers.</Typography>
+            <Typography variant="body2" sx={{ color: theme.palette.text.primary, display: 'inline' }}> provided for each question to determine your answers.</Typography>
           </Box>
         )}
       </Box>

--- a/components/calculator/RCWLinkInfo.tsx
+++ b/components/calculator/RCWLinkInfo.tsx
@@ -14,7 +14,6 @@ const details2 = 'The RCW links throughout the calculator send you to the online
 const details3 = 'Your WATCH report should list the crime name, degree of the offense, and the **RCW** law that was violated.';
 
 export default function RCWLinkInfo() {
-  const [infoPopup, setInfoPopup] = useState(false);
   const [RCWPopup, setRCWPopup] = useState(false);
 
   return (
@@ -28,7 +27,7 @@ export default function RCWLinkInfo() {
         }}
       >
         <IconButton
-          onClick={() => setInfoPopup(!infoPopup)}
+          onClick={() => setRCWPopup(!RCWPopup)}
           sx={{
             color: theme.palette.secondary.dark,
             '&:hover': {
@@ -40,33 +39,34 @@ export default function RCWLinkInfo() {
           <InfoOutlinedIcon style={{
             color: theme.palette.secondary.dark,
             fontSize: '24px',
+            alignSelf: 'flex-start',
+            marginTop: '4px',
           }}
           />
         </IconButton>
 
-        {infoPopup && (
-          <Box>
-            <Typography variant="body2" sx={{ color: theme.palette.text.primary, display: 'inline' }}>
-              Throughout the calculator, you may need to view the
-              {' '}
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                color: theme.palette.secondary.dark,
-                fontWeight: 'bold',
-                display: 'inline',
-                textDecoration: 'underline',
-                cursor: 'pointer',
-                '&:hover': { textDecoration: 'none' },
-              }}
-              onClick={() => setRCWPopup(true)}
-            >
-              RCW links
-            </Typography>
-            <Typography variant="body2" sx={{ color: theme.palette.text.primary, display: 'inline' }}> provided for each question to determine your answers.</Typography>
-          </Box>
-        )}
+        <Box>
+          <Typography variant="body2" sx={{ color: theme.palette.text.primary, display: 'inline' }}>
+            Throughout the calculator, you may need to view the
+            {' '}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              color: theme.palette.secondary.dark,
+              fontWeight: 'bold',
+              display: 'inline',
+              textDecoration: 'underline',
+              cursor: 'pointer',
+              '&:hover': { textDecoration: 'none' },
+            }}
+            onClick={() => setRCWPopup(true)}
+          >
+            RCW links
+          </Typography>
+          <Typography variant="body2" sx={{ color: theme.palette.text.primary, display: 'inline' }}> provided for each question to determine your answers.</Typography>
+        </Box>
+
       </Box>
 
       <Dialog

--- a/components/functional/DisclaimerBanner.tsx
+++ b/components/functional/DisclaimerBanner.tsx
@@ -6,7 +6,11 @@ import React from 'react';
 
 import theme from '../../styles/themes/theme.tsx';
 
-function DisclaimerBanner() {
+function DisclaimerBanner({ isHomePage }: { isHomePage: boolean }) {
+  if (!isHomePage) {
+    return null;
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <Box

--- a/components/helper/CustomButtons.tsx
+++ b/components/helper/CustomButtons.tsx
@@ -49,6 +49,8 @@ export function CalculatorButton({
   children?: React.ReactNode,
   handleClick?: () => void,
 }) {
+  const [strokeColor, setStrokeColor] = React.useState(theme.palette.text.light);
+
   return (
     <Button
       href={href}
@@ -73,9 +75,17 @@ export function CalculatorButton({
         boxShadow: 'none',
       }}
       onClick={handleClick}
+      onMouseEnter={() => setStrokeColor(theme.palette.text.primary!)}
+      onMouseLeave={() => setStrokeColor(theme.palette.text.light!)}
     >
       {children}
-      {hasArrow && <ArrowForwardIcon />}
+      {hasArrow && (
+      <ArrowForwardIcon sx={{
+        stroke: strokeColor,
+        strokeWidth: 0.5,
+      }}
+      />
+      )}
     </Button>
   );
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -123,7 +123,7 @@ export default function Header({ isCalc }: HeaderProps) {
       <Box
         component="nav"
         sx={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '80px', position: 'relative', px: 10.5,
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '80px', position: 'relative', px: 2,
         }}
       >
         <Drawer

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -43,13 +43,18 @@ export default function Header({ isCalc }: HeaderProps) {
   };
 
   const drawer = (
-    <Box onClick={handleDrawerToggle}>
-      <Box>
+    <Box
+      onClick={handleDrawerToggle}
+      sx={{
+        display: 'flex', flexDirection: 'column', height: '100vh', justifyContent: 'space-around',
+      }}
+    >
+      <Box sx={{
+        margin: '16px auto 16px 16px',
+      }}
+      >
         <IconButton
           aria-label="Close navigation"
-          sx={{
-            marginRight: 'auto',
-          }}
         >
           <ArrowForwardIos
             fontSize="large"
@@ -59,28 +64,41 @@ export default function Header({ isCalc }: HeaderProps) {
           />
         </IconButton>
       </Box>
-      <List className="nav-mobile" sx={{ transform: 'translateY(-20px)' }}>
+      <List className="nav-mobile" sx={{ transform: 'translateY(-60px)' }}>
         {navItems.map(({ href, text, sublist }) => (
           <React.Fragment key={text}>
-            <ListItem>
+            <ListItem
+              sx={{ paddingBottom: 0, paddingTop: 0 }}
+            >
               <ListItemButton
                 component={Link}
                 href={href}
+                sx={{
+                  paddingBottom: 0,
+                  paddingTop: 0,
+                }}
               >
                 <ListItemText
                   primary={text}
-                  primaryTypographyProps={{ style: { fontSize: '16px', fontWeight: '700' } }}
+                  primaryTypographyProps={{
+                    style:
+                    {
+                      fontSize: '16px', fontWeight: '700', fontFamily: theme.typography.button.fontFamily, marginBottom: 0,
+                    },
+                  }}
                 />
               </ListItemButton>
             </ListItem>
             <List sx={{ paddingLeft: '32px' }}>
               {sublist?.map((item) => (
                 <ListItem key={item} disablePadding>
-                  <ListItemButton sx={{ paddingTop: '8px', paddingBottom: '8px', paddingLeft: '8px' }}>
+                  <ListItemButton>
                     <ListItemText
                       primary={item}
                       primaryTypographyProps={{
-                        style: { fontSize: '16px', fontWeight: '500' },
+                        style: {
+                          fontSize: '16px', fontWeight: '500', fontFamily: theme.typography.button.fontFamily, marginBottom: 0,
+                        },
                       }}
                     />
                   </ListItemButton>
@@ -89,10 +107,14 @@ export default function Header({ isCalc }: HeaderProps) {
             </List>
           </React.Fragment>
         ))}
-        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <EligibilityButton />
-        </Box>
       </List>
+      <Box sx={{
+        display: 'flex', flexDirection: 'column', justifyContent: 'end', height: '128px',
+      }}
+      >
+        <Box />
+        <EligibilityButton />
+      </Box>
     </Box>
   );
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -91,7 +91,7 @@ export default function Header({ isCalc }: HeaderProps) {
             </ListItem>
             <List sx={{ paddingLeft: '32px' }}>
               {sublist?.map((item) => (
-                <ListItem key={item} disablePadding>
+                <ListItem key={item.text} disablePadding>
                   <ListItemButton>
                     <ListItemText
                       primary={item.text}

--- a/components/layout/HeroBanner.tsx
+++ b/components/layout/HeroBanner.tsx
@@ -39,6 +39,9 @@ export default function HeroBanner({
       sx={{
         ...heroStyles,
         backgroundImage: background,
+        height: {
+          lg: '660px',
+        },
       }}
       textAlign="left"
     >

--- a/components/layout/HeroBanner.tsx
+++ b/components/layout/HeroBanner.tsx
@@ -59,7 +59,6 @@ export default function HeroBanner({
           sx={{
             color: 'text.light',
             pt: 40,
-            fontSize: 48,
           }}
         >
           {header}

--- a/components/layout/HeroBanner.tsx
+++ b/components/layout/HeroBanner.tsx
@@ -20,7 +20,6 @@ const heroStyles: SxProps = {
   backgroundPosition: 'center',
   color: 'primary.contrastText',
   width: '100%',
-  height: '100vh',
   py: {
     xs: 0.5,
     md: 8,
@@ -39,9 +38,6 @@ export default function HeroBanner({
       sx={{
         ...heroStyles,
         backgroundImage: background,
-        height: {
-          lg: '660px',
-        },
       }}
       textAlign="left"
     >

--- a/cypress/e2e/access-calculator.cy.ts
+++ b/cypress/e2e/access-calculator.cy.ts
@@ -2,7 +2,7 @@ describe('From Home Page', () => {
   it('its possible to access calculator from Header btn', () => {
     cy.visit('/');
     // https://docs.cypress.io/guides/references/best-practices#Assigning-Return-Values
-    cy.get('a:contains("Access Calculator"):visible')
+    cy.get('a:contains("Check eligibility"):visible')
       .as('accessCalculatorBtns')
       .should('have.length', 2);
     // Click on ACCESS CALCULATOR from Header
@@ -25,7 +25,7 @@ describe('From Home Page', () => {
 
   it('its possible to access calculator from Hero btn', () => {
     cy.visit('/');
-    cy.get('a:contains("Access Calculator"):visible').as('accessCalculatorBtns');
+    cy.get('a:contains("Check eligibility"):visible').as('accessCalculatorBtns');
     cy.get('@accessCalculatorBtns').should('have.length', 2);
     cy.get('@accessCalculatorBtns').eq(1).click();
     cy.url().should('include', '/calculator/head-initial-1-cont');

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,6 +31,8 @@ function MyApp({
   const stringToCheck = 'calculator';
   const isCalc = asPath.includes(stringToCheck);
 
+  const isHomePage = asPath === '/';
+
   return (
     <CacheProvider value={emotionCache}>
       <Head>
@@ -40,7 +42,7 @@ function MyApp({
         <>
           <CssBaseline />
           <Header isCalc={isCalc} />
-          <DisclaimerBanner />
+          <DisclaimerBanner isHomePage={isHomePage} />
           <Component {...pageProps} />
           <Footer isCalc={isCalc} />
         </>

--- a/pages/calculator/[slug].tsx
+++ b/pages/calculator/[slug].tsx
@@ -49,7 +49,7 @@ export default function CalculatorSlugRoute({ page, calculatorConfig }: StaticCa
         ref={contentRef}
         component={Container}
         sx={{
-          minHeight: '35rem',
+          minHeight: '40rem',
           display: 'flex',
           flexDirection: 'column',
           maxWidth: {


### PR DESCRIPTION
Completes the following tasks in Trello:

- [x] Only have disclaimer banner on home page
- [x] Fix mobile side nav margins and padding
- [x] Specific height for hero image on large screens
- [x] Button exceptions: exclude HEAD and blake eligibility pages from having absolutely positioned buttons
- [x] Fix the yes/no buttons on mobile, too wide and too much space
- [x] Fix not sure dialog - update typography styles
- [ ] Complete progress bar
- [ ] Fix white section under footer - shows on tablet screens
- [x] Add stroke to calculator button arrows
- [x] Fix RCW that jumps when opened on some screens
- [x] Fix padding issue that is pushing the hamburger to close to center on mobile