### PR TITLE
update file and folder structure for why-vacate and get-started subpages

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -75,10 +75,10 @@ export default function Header({ isCalc }: HeaderProps) {
             </ListItem>
             <List sx={{ paddingLeft: '32px' }}>
               {sublist?.map((item) => (
-                <ListItem key={item} disablePadding>
-                  <ListItemButton sx={{ paddingTop: '8px', paddingBottom: '8px', paddingLeft: '8px' }}>
+                <ListItem key={item.text} disablePadding>
+                  <ListItemButton component={Link} href={item.href} sx={{ paddingTop: '8px', paddingBottom: '8px', paddingLeft: '8px' }}>
                     <ListItemText
-                      primary={item}
+                      primary={item.text}
                       primaryTypographyProps={{
                         style: { fontSize: '16px', fontWeight: '500' },
                       }}
@@ -175,7 +175,7 @@ export default function Header({ isCalc }: HeaderProps) {
                       }}
                     >
                       {item.sublist?.map((link) => (
-                        <Link key={link} href="/" passHref style={{ textDecoration: 'none' }}>
+                        <Link key={link.text} href={link.href} passHref style={{ textDecoration: 'none' }}>
                           <Box
                             sx={{
                               color: theme.palette.text.light,
@@ -190,7 +190,7 @@ export default function Header({ isCalc }: HeaderProps) {
                               '&:hover': { backgroundColor: theme.palette.text.secondary },
                             }}
                           >
-                            {link}
+                            {link.text}
                             <ChevronRight />
                           </Box>
                         </Link>

--- a/content/content.types.ts
+++ b/content/content.types.ts
@@ -56,7 +56,10 @@ export interface Info {
 export interface NavItem {
     href: string;
     text: string;
-    sublist?: string[];
+    sublist?: {
+        text: string;
+        href: string;
+    }[];
 }
 
 export interface Button {

--- a/content/navItems.ts
+++ b/content/navItems.ts
@@ -8,12 +8,36 @@ const navItems: NavItem[] = [
   {
     href: '/get-started',
     text: 'Get started',
-    sublist: ['Gather your documentation', 'Determine your eligibility', 'File with the court'],
+    sublist: [
+      {
+        href: '/get-started/gather-your-documentation',
+        text: 'Gather your documentation',
+      },
+      {
+        href: '/get-started/determine-your-eligibility',
+        text: 'Determine your eligibility',
+      },
+      {
+        href: '/get-started/file-with-the-court',
+        text: 'File with the court',
+      }],
   },
   {
     href: '/why-vacate',
     text: 'Why vacate',
-    sublist: ['Employment benefits', 'Housing benefits', 'Education benefits'],
+    sublist: [
+      {
+        href: '/why-vacate/employment-benefits',
+        text: 'Employment benefits',
+      },
+      {
+        href: '/why-vacate/housing-benefits',
+        text: 'Housing benefits',
+      },
+      {
+        href: '/why-vacate/educational-benefits',
+        text: 'Educational benefits',
+      }],
   },
 ];
 

--- a/pages/get-started/determine-your-eligibility.tsx
+++ b/pages/get-started/determine-your-eligibility.tsx
@@ -1,0 +1,1 @@
+export default function DetermineYourEligibility() {}

--- a/pages/get-started/file-with-the-court.tsx
+++ b/pages/get-started/file-with-the-court.tsx
@@ -1,0 +1,1 @@
+export default function FileWithTheCourt() {}

--- a/pages/get-started/gather-your-documentation.tsx
+++ b/pages/get-started/gather-your-documentation.tsx
@@ -1,0 +1,1 @@
+export default function GatherYourDocumentation() {}

--- a/pages/get-started/index.tsx
+++ b/pages/get-started/index.tsx
@@ -6,16 +6,16 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MuiMarkdown from 'mui-markdown';
 import React from 'react';
 
-import useScroll from '../components/functional/CustomScroll.tsx';
-import externalLinks from '../components/functional/ExternalLinks.tsx';
-import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
-import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';
-import FactCard from '../components/layout/FactCard.tsx';
-import GetStartedStep from '../components/layout/GetStartedStep.tsx';
-import HeroBanner from '../components/layout/HeroBanner.tsx';
-import ImageContainer from '../components/layout/ImageContainer.tsx';
-import SectionContainer, { sectionContainerSxProps } from '../components/layout/SectionContainer.tsx';
-import content from '../content/get-started.ts';
+import useScroll from '../../components/functional/CustomScroll.tsx';
+import externalLinks from '../../components/functional/ExternalLinks.tsx';
+import IndividualPageHead from '../../components/helper/IndividualPageHead.tsx';
+import AccordionBuilder from '../../components/layout/AccordionBuilder.tsx';
+import FactCard from '../../components/layout/FactCard.tsx';
+import GetStartedStep from '../../components/layout/GetStartedStep.tsx';
+import HeroBanner from '../../components/layout/HeroBanner.tsx';
+import ImageContainer from '../../components/layout/ImageContainer.tsx';
+import SectionContainer, { sectionContainerSxProps } from '../../components/layout/SectionContainer.tsx';
+import content from '../../content/get-started.ts';
 
 const newSectionContainerSxProps: SxProps = {
   ...sectionContainerSxProps, px: 0, textAlign: 'left',

--- a/pages/why-vacate/educational-benefits.tsx
+++ b/pages/why-vacate/educational-benefits.tsx
@@ -1,0 +1,1 @@
+export default function EducationalBenefits() {}

--- a/pages/why-vacate/employment-benefits.tsx
+++ b/pages/why-vacate/employment-benefits.tsx
@@ -1,0 +1,1 @@
+export default function EmploymentBenefits() {}

--- a/pages/why-vacate/housing-benefits.tsx
+++ b/pages/why-vacate/housing-benefits.tsx
@@ -1,0 +1,1 @@
+export default function HousingBenefits() {}

--- a/pages/why-vacate/index.tsx
+++ b/pages/why-vacate/index.tsx
@@ -5,15 +5,15 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 
-import useScroll from '../components/functional/CustomScroll.tsx';
-import externalLinks from '../components/functional/ExternalLinks.tsx';
-import IndividualPageHead from '../components/helper/IndividualPageHead.tsx';
-import AccordionBuilder from '../components/layout/AccordionBuilder.tsx';
-import GridItemCard from '../components/layout/GridItem.tsx';
-import HeroBanner from '../components/layout/HeroBanner.tsx';
-import PaperSection from '../components/layout/PaperSection.tsx';
-import SectionContainer from '../components/layout/SectionContainer.tsx';
-import content from '../content/why-vacate.ts';
+import useScroll from '../../components/functional/CustomScroll.tsx';
+import externalLinks from '../../components/functional/ExternalLinks.tsx';
+import IndividualPageHead from '../../components/helper/IndividualPageHead.tsx';
+import AccordionBuilder from '../../components/layout/AccordionBuilder.tsx';
+import GridItemCard from '../../components/layout/GridItem.tsx';
+import HeroBanner from '../../components/layout/HeroBanner.tsx';
+import PaperSection from '../../components/layout/PaperSection.tsx';
+import SectionContainer from '../../components/layout/SectionContainer.tsx';
+import content from '../../content/why-vacate.ts';
 
 export default function WhyVacatePage() {
   const theme = useTheme();


### PR DESCRIPTION
Updates the file and folder structure to accommodate the new dropdown and subpages for why-vacate and get-started. There is now a new folder for each in the pages directory, and the index.tsx file in each is the formerly /why-vacate and /get-started pages. This should allow for everyone to easily continue work on the rest of these pages.