### PR TITLE
add bottom margin to body2 elements, use h6 in sanity to style lists as body2 without margin

### DIFF
--- a/utils/portableTextComponents.tsx
+++ b/utils/portableTextComponents.tsx
@@ -7,7 +7,8 @@ const portableTextComponent = {
   block: {
     headingCalculator: ({ children }: any) => <Typography style={theme.typography.headingCalculator}>{children}</Typography>,
     body1: ({ children }: any) => <Typography variant="body1" style={theme.typography.body1}>{children}</Typography>,
-    body2: ({ children }: any) => <Typography variant="body2" style={theme.typography.body2}>{children}</Typography>,
+    body2: ({ children }: any) => <Typography variant="body2" style={{ ...theme.typography.body2, marginBottom: '24px' }}>{children}</Typography>,
+    h6: ({ children }: any) => <Typography variant="body2" style={theme.typography.body2}>{children}</Typography>,
   },
   marks: {
     link: ({ children, value }: any) => {


### PR DESCRIPTION
Changes to content in Sanity and styling of block content to add margins to body2 text.