### PR TITLE
Reset state after when using the browser's back button

### DIFF
--- a/components/calculator/CalcHeader.tsx
+++ b/components/calculator/CalcHeader.tsx
@@ -2,6 +2,7 @@ import {
   Box, Container, Step, StepConnector, Stepper, styled,
   Typography,
 } from '@mui/material';
+import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
 import theme from '../../styles/themes/theme.tsx';
@@ -139,8 +140,13 @@ function CustomHorizontalStepper() {
 }
 
 export default function CalcHeader({ page }:
-    { page: StaticCalcProps['page']
-    }) {
+  {
+    page: StaticCalcProps['page']
+  }) {
+  const router = useRouter();
+  useEffect(() => {
+  }, [router.query.slug]);
+
   const isPageIncludedInStepper = () => {
     const isMisSpecialCase = page.slug.includes('m-offense-pro') || page.slug.includes('m-offense-mari') || page.slug.includes('m-offense-fish');
     const excludedPageSlugs = ['start', 'head'];
@@ -151,6 +157,7 @@ export default function CalcHeader({ page }:
   return (
     <Container
       id="calc-head-container"
+      key={router.asPath}
       sx={{
         marginTop: {
           xs: '40px',


### PR DESCRIPTION
### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description

Previously, the progress bar stayed outdated whenever the user clicks on the browser's back button. I resolved the issue by ensuring that the CalcHeader component is remounted whenever navigation changes using useEffect and useRouter. 


Fixes Trello Ticket- link [here](https://trello.com/c/QeUDNzm9/20-fix-progress-bar) 

### Image
![image](https://github.com/user-attachments/assets/473d8dcf-7081-4a55-b75b-97c195dec498)


### Related Docs:
Next.js Doc on Resetting State after Navigation - link [here](https://nextjs.org/docs/pages/api-reference/functions/use-router#resetting-state-after-navigation)

