### PR TITLE
Align disclaimer icon

### DIFF
--- a/components/layout/DisclaimerBanner.tsx
+++ b/components/layout/DisclaimerBanner.tsx
@@ -20,19 +20,22 @@ function DisclaimerBanner({ isHomePage }: { isHomePage: boolean }) {
           justifyContent: 'center',
           bgcolor: 'secondary.dark',
           py: 1,
+          px: 2,
           color: 'white',
         }}
       >
         <Box sx={{
-          display: 'flex', px: 2, width: { xs: '100%', md: '85%' },
+          display: 'flex', width: { xs: '100%', md: '85%' },
         }}
         >
-          <ErrorOutlineIcon sx={{
-            // width: '24px',
-            // height: '32px',
-            // pb: 1,
+          <Box sx={{
+            display: 'flex',
+            direction: 'column',
+            alignItems: 'center',
           }}
-          />
+          >
+            <ErrorOutlineIcon />
+          </Box>
           <Box sx={{ pl: 1 }}>
             Since we are an open-sourced project, links may be broken or outdated. Last updated: 2024-04-12
           </Box>


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
### Description

Previously, the disclaimer icon would be slightly misaligned. I addressed this by wrapping the icon in a parent div and applied flex styling so that the icon would always be centered vertically.

## Trello Ticket [here](https://trello.com/c/jJjgoLDj/77-fix-alignment-of-disclaimer-bar-icon)

### Screenshots
#### Before
![image](https://github.com/user-attachments/assets/90ded2d3-e9bb-4ac5-98d2-a9931af87567)
![image](https://github.com/user-attachments/assets/9b8f4924-0e69-430f-b672-88dcb102dc0d)


#### After
![image](https://github.com/user-attachments/assets/6932a71f-498e-4520-bfcd-2516e6078cc3)
![image](https://github.com/user-attachments/assets/182aaf61-19fd-4107-b45e-4e8cfebe2d7d)