### PR TITLE
adjust flex properties of CTA box to fix item misalignment

### DIFF
--- a/pages/get-started/determine-your-eligibility.tsx
+++ b/pages/get-started/determine-your-eligibility.tsx
@@ -20,11 +20,13 @@ export function CheckConvictionCTABox({ text }: {text: string}) {
           xs: 'column',
           md: 'row',
         },
-        justifyContent: 'center',
+        justifyContent: {
+          xs: 'space-between',
+          sm: 'center',
+        },
         padding: {
           xs: '32px 24px',
-          sm: '48px',
-          md: '0px',
+          sm: '0px',
         },
         gap: {
           xs: '64px',
@@ -32,6 +34,8 @@ export function CheckConvictionCTABox({ text }: {text: string}) {
           md: '0px',
         },
         height: {
+          xs: '232px',
+          sm: '296px',
           md: '318px',
         },
       }}
@@ -39,7 +43,8 @@ export function CheckConvictionCTABox({ text }: {text: string}) {
         <Box sx={{
           width: 'fit-content',
           margin: {
-            sm: 'auto',
+            sm: '0px auto',
+            md: 'auto',
           },
         }}
         >
@@ -52,7 +57,8 @@ export function CheckConvictionCTABox({ text }: {text: string}) {
           padding: {
           },
           margin: {
-            sm: 'auto',
+            sm: '0px auto',
+            md: 'auto',
           },
         }}
         >

--- a/pages/get-started/determine-your-eligibility.tsx
+++ b/pages/get-started/determine-your-eligibility.tsx
@@ -16,23 +16,28 @@ export function CheckConvictionCTABox({ text }: {text: string}) {
     }}
     >
       <GSContainer sx={{
-        height: {
-          xs: '232px',
-          sm: '296px',
-        },
         flexDirection: {
           xs: 'column',
           md: 'row',
         },
         justifyContent: 'center',
+        padding: {
+          xs: '32px 24px',
+          sm: '48px',
+          md: '0px',
+        },
+        gap: {
+          xs: '64px',
+          sm: '48px',
+          md: '0px',
+        },
+        height: {
+          md: '318px',
+        },
       }}
       >
         <Box sx={{
           width: 'fit-content',
-          padding: {
-            xs: '32px 0px',
-            sm: '0px',
-          },
           margin: {
             sm: 'auto',
           },


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Trello ticket [here](https://trello.com/c/PZ5dLxG9/78-fix-section-margins)

The padding of the container that the get started pages use gets its padding from the figma, but it is just a base to start from and as all of the containers in the figma tend to vary in their top and bottom padding, many of the containers require some modification. Originally I created these containers because I was having issues with the SectionContainer component taking in any sx props and overriding everything which caused lots of unwanted behavior. Later after using these new containers, during a review of the components I realized that the SectionContainer was missing the spread in of the sx props below its own sx props, which ended up resolving the original issue and allowing me to fix some things on the home page quickly. Anyways, these containers are still being used so the fix here was adjusting the padding on smaller breakpoints and then adding a fixed height once hitting the medium breakpoint.
