### PR TITLE
fix list item spacing

### DIFF
--- a/components/layout/AccordionBuilder.tsx
+++ b/components/layout/AccordionBuilder.tsx
@@ -75,6 +75,9 @@ export default function InfoDropdown({
               props: {
                 variant: 'body2',
                 component: 'li',
+                style: {
+                  marginBottom: '10px',
+                },
               },
             },
             a: {


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Description

Trello ticket [here](https://trello.com/c/vDvyLRif/76-fix-faq-list-item-spacing)

The list items in the `AccordionBuilder` component did not have any spacing. According to the figma I found a 10px gap when selecting the container so I added that as bottom margin to each list item.