### PR TITLE
Style hamburger menu

### DIFF
--- a/components/CustomButtons.tsx
+++ b/components/CustomButtons.tsx
@@ -20,6 +20,7 @@ export function EligibilityButton() {
         height: '40px',
         gap: '8px',
         color: 'text.secondary',
+        letterSpacing: 0,
         '&:hover': {
           backgroundColor: 'tertiary.light',
         },

--- a/components/CustomButtons.tsx
+++ b/components/CustomButtons.tsx
@@ -15,8 +15,10 @@ export function EligibilityButton() {
       aria-label="Access our eligibility calculator"
       sx={{
         whiteSpace: 'nowrap',
-        py: 1,
-        px: 3,
+        padding: '10px 16px',
+        width: '191px',
+        height: '40px',
+        gap: '8px',
         color: 'text.secondary',
         '&:hover': {
           backgroundColor: 'tertiary.light',
@@ -28,13 +30,13 @@ export function EligibilityButton() {
           backgroundColor: 'tertiary',
           boxShadow: '0 0 0 4px #0000EE99',
         },
-        margin: '.625rem auto',
       }}
     >
       Check eligibility
       <ArrowForwardIcon sx={{
         stroke: theme.palette.text.secondary,
         strokeWidth: 0.5,
+        fontSize: '18px',
       }}
       />
     </Button>
@@ -80,17 +82,17 @@ export function CalculatorButton({
     >
       {children}
       {hasArrow && (
-      <ArrowForwardIcon sx={{
-        stroke: strokeColor,
-        strokeWidth: 0.5,
-      }}
-      />
+        <ArrowForwardIcon sx={{
+          stroke: strokeColor,
+          strokeWidth: 0.5,
+        }}
+        />
       )}
     </Button>
   );
 }
 
-export function TextButtonGreen({ text, href }: {text: string, href: string}) {
+export function TextButtonGreen({ text, href }: { text: string, href: string }) {
   return (
     <Button
       href={href}
@@ -125,7 +127,7 @@ export function TextButtonGreen({ text, href }: {text: string, href: string}) {
   );
 }
 
-export function DarkButton({ text, href }: {text: string, href: string}) {
+export function DarkButton({ text, href }: { text: string, href: string }) {
   const [strokeColor, setStrokeColor] = React.useState(theme.palette.text.light);
   return (
     <Button
@@ -163,7 +165,7 @@ export function DarkButton({ text, href }: {text: string, href: string}) {
   );
 }
 
-export function LightButton({ text, href }: {text: string, href: string}) {
+export function LightButton({ text, href }: { text: string, href: string }) {
   return (
     <Button
       href={href}

--- a/components/CustomButtons.tsx
+++ b/components/CustomButtons.tsx
@@ -35,7 +35,6 @@ export function EligibilityButton() {
       Check eligibility
       <ArrowForwardIcon sx={{
         stroke: theme.palette.text.secondary,
-        strokeWidth: 0.5,
         fontSize: '18px',
       }}
       />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -67,7 +67,7 @@ export default function Header({ isCalc }: HeaderProps) {
         </IconButton>
       </Box>
 
-      <List className="nav-mobile">
+      <List className="nav-mobile" sx={{ width: '226px' }}>
         {navItems.map(({ href, text, sublist }) => (
           <React.Fragment key={text}>
             <ListItem
@@ -97,13 +97,14 @@ export default function Header({ isCalc }: HeaderProps) {
                 />
               </ListItemButton>
             </ListItem>
-            <List sx={{ paddingLeft: '24px', paddingTop: '0px', paddingBottom: '0px' }}>
+            <List sx={{ paddingTop: '0px', paddingBottom: '0px' }}>
               {sublist?.map((item) => (
                 <ListItem key={item.text} disablePadding>
                   <ListItemButton
                     href={item.href}
                     component={Link}
                     sx={{
+                      paddingLeft: '24px',
                       '&:hover': {
                         backgroundColor: theme.palette.text.secondary,
                       },

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -46,36 +46,37 @@ export default function Header({ isCalc }: HeaderProps) {
     <Box
       onClick={handleDrawerToggle}
       sx={{
-        display: 'flex', flexDirection: 'column', height: '100vh', justifyContent: 'space-around',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        marginTop: '2px',
+        padding: '24px 16px 24px 16px',
+        gap: '16px',
       }}
     >
-      <Box sx={{
-        margin: '16px auto 16px 16px',
-      }}
-      >
+      <Box>
         <IconButton
           aria-label="Close navigation"
         >
           <ArrowForwardIos
-            fontSize="large"
             sx={{
               color: theme.palette.text.light,
             }}
           />
         </IconButton>
       </Box>
-      <List className="nav-mobile" sx={{ transform: 'translateY(-60px)' }}>
+
+      <List className="nav-mobile">
         {navItems.map(({ href, text, sublist }) => (
           <React.Fragment key={text}>
-            <ListItem
-              sx={{ paddingBottom: 0, paddingTop: 0 }}
-            >
+            <ListItem disablePadding>
               <ListItemButton
                 component={Link}
                 href={href}
                 sx={{
-                  paddingBottom: 0,
-                  paddingTop: 0,
+                  '&:hover': {
+                    backgroundColor: theme.palette.text.secondary,
+                  },
                 }}
               >
                 <ListItemText
@@ -83,24 +84,33 @@ export default function Header({ isCalc }: HeaderProps) {
                   primaryTypographyProps={{
                     style:
                     {
-                      fontSize: '16px', fontWeight: '700', fontFamily: theme.typography.button.fontFamily, marginBottom: 0,
+                      fontSize: '16px',
+                      fontWeight: '700',
+                      fontFamily: theme.typography.button.fontFamily,
                     },
                   }}
                 />
               </ListItemButton>
             </ListItem>
-            <List sx={{ paddingLeft: '32px' }}>
+            <List sx={{ paddingLeft: '24px' }}>
               {sublist?.map((item) => (
                 <ListItem key={item.text} disablePadding>
                   <ListItemButton
                     href={item.href}
                     component={Link}
+                    sx={{
+                      '&:hover': {
+                        backgroundColor: theme.palette.text.secondary,
+                      },
+                    }}
                   >
                     <ListItemText
                       primary={item.text}
                       primaryTypographyProps={{
                         style: {
-                          fontSize: '16px', fontWeight: '500', fontFamily: theme.typography.button.fontFamily, marginBottom: 0,
+                          fontSize: '16px',
+                          fontWeight: '500',
+                          fontFamily: theme.typography.button.fontFamily,
                         },
                       }}
                     />
@@ -112,10 +122,9 @@ export default function Header({ isCalc }: HeaderProps) {
         ))}
       </List>
       <Box sx={{
-        display: 'flex', flexDirection: 'column', justifyContent: 'end', height: '128px',
+        paddingTop: '16px',
       }}
       >
-        <Box />
         <EligibilityButton />
       </Box>
     </Box>
@@ -126,7 +135,12 @@ export default function Header({ isCalc }: HeaderProps) {
       <Box
         component="nav"
         sx={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '80px', position: 'relative', px: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          height: '80px',
+          position: 'relative',
+          px: 2,
         }}
       >
         <Drawer
@@ -134,6 +148,9 @@ export default function Header({ isCalc }: HeaderProps) {
           onClose={handleDrawerToggle}
           ModalProps={{ keepMounted: true }}
           anchor="right"
+          PaperProps={{
+            sx: { width: '72%' },
+          }}
         >
           {drawer}
         </Drawer>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -25,7 +25,7 @@ interface HeaderProps {
 
 export default function Header({ isCalc }: HeaderProps) {
   const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.down('md'));
+  const matchesMd = useMediaQuery(theme.breakpoints.down('md'));
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -155,7 +155,7 @@ export default function Header({ isCalc }: HeaderProps) {
           {drawer}
         </Drawer>
         <Box sx={{ width: '100%' }}>
-          {matches && (
+          {matchesMd && (
             <IconButton aria-label="open sidebar menu" onClick={handleDrawerToggle} sx={{ display: 'flex', width: '100%' }}>
               <Menu
                 sx={{
@@ -165,7 +165,7 @@ export default function Header({ isCalc }: HeaderProps) {
               />
             </IconButton>
           )}
-          {!matches && (
+          {!matchesMd && (
             <Box
               className="desktop-nav-list"
               sx={{
@@ -250,7 +250,7 @@ export default function Header({ isCalc }: HeaderProps) {
           )}
         </Box>
         <NavigationLogo sx={{ position: 'absolute', left: '50%', transform: 'translate(-50%, 0)' }} />
-        {!matches && (
+        {!matchesMd && (
           <Box>
             <EligibilityButton />
           </Box>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -26,7 +26,6 @@ interface HeaderProps {
 export default function Header({ isCalc }: HeaderProps) {
   const theme = useTheme();
   const matchesMd = useMediaQuery(theme.breakpoints.down('md'));
-  const matchesXs = useMediaQuery(theme.breakpoints.down('xs'));
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -58,6 +57,7 @@ export default function Header({ isCalc }: HeaderProps) {
       <Box>
         <IconButton
           aria-label="Close navigation"
+          sx={{ padding: 0 }}
         >
           <ArrowForwardIos
             sx={{
@@ -70,7 +70,9 @@ export default function Header({ isCalc }: HeaderProps) {
       <List className="nav-mobile">
         {navItems.map(({ href, text, sublist }) => (
           <React.Fragment key={text}>
-            <ListItem disablePadding>
+            <ListItem
+              disablePadding
+            >
               <ListItemButton
                 component={Link}
                 href={href}
@@ -88,12 +90,14 @@ export default function Header({ isCalc }: HeaderProps) {
                       fontSize: '16px',
                       fontWeight: '700',
                       fontFamily: theme.typography.button.fontFamily,
+
                     },
                   }}
+                  sx={{ margin: 0 }}
                 />
               </ListItemButton>
             </ListItem>
-            <List sx={{ paddingLeft: '24px' }}>
+            <List sx={{ paddingLeft: '24px', paddingTop: '0px', paddingBottom: '0px' }}>
               {sublist?.map((item) => (
                 <ListItem key={item.text} disablePadding>
                   <ListItemButton
@@ -123,7 +127,7 @@ export default function Header({ isCalc }: HeaderProps) {
         ))}
       </List>
       <Box sx={{
-        paddingTop: matchesXs ? '16px' : '72px',
+        marginTop: 'auto',
       }}
       >
         <EligibilityButton />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -26,6 +26,7 @@ interface HeaderProps {
 export default function Header({ isCalc }: HeaderProps) {
   const theme = useTheme();
   const matchesMd = useMediaQuery(theme.breakpoints.down('md'));
+  const matchesXs = useMediaQuery(theme.breakpoints.down('xs'));
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -122,7 +123,7 @@ export default function Header({ isCalc }: HeaderProps) {
         ))}
       </List>
       <Box sx={{
-        paddingTop: '16px',
+        paddingTop: matchesXs ? '16px' : '72px',
       }}
       >
         <EligibilityButton />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -54,7 +54,7 @@ export default function Header({ isCalc }: HeaderProps) {
         gap: '16px',
       }}
     >
-      <Box>
+      <Box sx={{ paddingLeft: '10px' }}>
         <IconButton
           aria-label="Close navigation"
           sx={{ padding: 0 }}
@@ -127,7 +127,7 @@ export default function Header({ isCalc }: HeaderProps) {
         ))}
       </List>
       <Box sx={{
-        marginTop: 'auto',
+        paddingLeft: '16px',
       }}
       >
         <EligibilityButton />


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Design change

### Description
Hamburger menu did not fully match Figma. Updates include:
- Ensuring the menu covers 72% of the screen when opened
- Adding a dark blue hover background for improved accessibility
- Adjusting the spacing for proper alignment
- Updating button styles

Trello ticket [link](https://trello.com/c/5kvnaoL4/82-hamburger-menu-styles-do-not-match-figma-designs)  
Figma [link 1](https://www.figma.com/design/NzfRmePoBPp4yrxTMrNRz1/CV-Website-Update.-4.2024?node-id=1134-39595&node-type=frame&t=pkcvGwZS7JhQNOvR-0)
Figma [link 2](https://www.figma.com/design/NzfRmePoBPp4yrxTMrNRz1/CV-Website-Update.-4.2024?node-id=578-7808&node-type=instance&t=avzUTiwbVxw9MgNK-0)

### Screenshots

#### Before
<img width="490" alt="image" src="https://github.com/user-attachments/assets/ca22e9e1-8cb2-495a-bf13-3aa349bdaa63">


#### After
<img width="490" alt="image" src="https://github.com/user-attachments/assets/46a27cc6-f121-49f8-b40a-d40a9c006d3f">


