### PR TITLE
refactor progress bar switch

### DIFF
--- a/components/calculator/CalcHeader.tsx
+++ b/components/calculator/CalcHeader.tsx
@@ -30,17 +30,12 @@ function CustomHorizontalStepper() {
   const handleNext = () => {
     const { pathname } = window.location;
 
-    switch (true) {
-      case pathname.includes('classcpro'):
-      case pathname.includes('classbpro'):
-        setIsProPath(true);
-        break;
-      case pathname.includes('eligible'):
-      case pathname.includes('ineligible'):
-        setIsEndPage(true);
-        break;
-      default:
-        break;
+    if (pathname.includes('classcpro') || pathname.includes('classbpro')) {
+      setIsProPath(true);
+    }
+
+    if (pathname.includes('eligible') || pathname.includes('ineligible')) {
+      setIsEndPage(true);
     }
 
     type Items = {


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Previously we had refactored a block of if statements checking conditions for the progress bar into a switch statement, which was cleaner, however it had some unintended side effects. The switch statement was catching the pathname including 'classcpro' or 'classbpro' to set the progress bar to 2 sections instead of 3 on felony prostitution paths, but then it was breaking and never catching the pathname including 'eligible' or 'ineligible' to set the progress bar on end pages correctly.

Since the time of the change to the switch statement, some other parts of the switch statement were removed, and refactoring this into 2 if statements instead of the 4 or more that it previously was, did not revert us back to very messy code. Using if statements, we are able to catch both conditions on the felony prostitution paths, and the progress bar is working as expected.

![image](https://github.com/user-attachments/assets/dd18cfb6-dc27-45ba-85bd-83ef897f52c1)
