### PR TITLE
allow 5 card carousel to spread over large screens

### DIFF
--- a/components/layout/CarouselBuilder.tsx
+++ b/components/layout/CarouselBuilder.tsx
@@ -70,7 +70,7 @@ export default function CarouselBuilder({
       sx={{
         paddingLeft: {
           xs: '24px',
-          sm: '0px',
+          md: '36px',
         },
       }}
     >
@@ -85,9 +85,6 @@ export default function CarouselBuilder({
           transform: `translateX(-${currentIndex * (cardWidth + 32)}px)`,
           transition: 'transform 0.5s ease-in-out',
           gap: useGetStartedCards ? '32px' : '0px',
-          justifyContent: {
-            md: 'space-between',
-          },
 
         }}
         >

--- a/pages/get-started/file-with-the-court.tsx
+++ b/pages/get-started/file-with-the-court.tsx
@@ -87,6 +87,10 @@ export default function FileWithTheCourt() {
             sm: '72px 0px 52px 24px',
             md: '72px 0px 52px 0px',
           },
+          maxWidth: {
+            md: '1399px',
+            lg: '1599px',
+          },
         }}
       >
         <Grid container>


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Design change

### Description

This adjusts the 5 card carousel on `get-started/file-with-the-court`. Previously the carousel cut off at `936px` and only showed a max of 3 cards, leaving it easy to miss the last 2 cards on the page. According to the figma, the carousel would not  break but rather as the screen size expanded the cards would spread out across the page. The issue here is that once we pass the medium breakpoint (`1000px`) we move from specific `x` padding to `auto` `x` margin, and according to the figma we only wanted the left side to have the margin. In this PR, it slightly differs from the figma in that the carousel spreads the cards across the page but does not align left with the page content. Designers will need to review and make a decision.

### Screenshots

#### After
##### MD
![image](https://github.com/user-attachments/assets/46471edf-e085-458b-ae72-3b9a14761005)

![image](https://github.com/user-attachments/assets/8e1cd5cf-beeb-4ba7-be66-86d238bfd7c2)
##### LG
![image](https://github.com/user-attachments/assets/7ca1b172-1cca-4d26-8ab5-2a9c30a1827a)

##### XL
![image](https://github.com/user-attachments/assets/bd640f9d-ef3f-46bb-a7d8-cf0961ae0f6c)



