### PR TITLE
update resource page copy

### DIFF
--- a/pages/see-more-resources.tsx
+++ b/pages/see-more-resources.tsx
@@ -50,8 +50,8 @@ const vocationalProgramsForOccupationalLicensesMarkdown = `
 Some vocational programs have restrictions based on your criminal record. \n
 If you are prevented from getting an  occupational license, you might be eligible for a Certificate of Restoration of Opportunity (CROP).  \n
 This certificate can prevent most licensed professions from denying you if you meet all other requirements. \n
-For more information about a CROP, visit [https://www.washingtonlawhelp.org/resource/certificate-of-restoration-of-opportunity-crop](https://www.washingtonlawhelp.org/resource/certificate-of-restoration-of-opportunity-crop) \n
-Here is a packet to help file for a CROP: [https://www.washingtonlawhelp.org/resource/filing-a-petition-for-certificate-of-restoration-of-opportunity-crop](https://www.washingtonlawhelp.org/resource/filing-a-petition-for-certificate-of-restoration-of-opportunity-crop) \n
+For more information about a CROP, visit [Washington Law Help’s Resources](https://www.washingtonlawhelp.org/resource/certificate-of-restoration-of-opportunity-crop) \n
+Here is a packet to help file for a CROP: [Petition for Certificate of Restoration](https://www.washingtonlawhelp.org/resource/filing-a-petition-for-certificate-of-restoration-of-opportunity-crop) \n
 `;
 
 export default function SeeMoreResources() {
@@ -183,11 +183,9 @@ export default function SeeMoreResources() {
         </Box>
       </SMRContainer>
       <SMRContainer sx={{ gap: '24' }}>
-        {/* <Box> */}
         <Typography variant="h3" sx={{ mb: '24px' }}>
           Vocational programs for occupational licensing
         </Typography>
-        {/* </Box> */}
         <MuiMarkdown overrides={{
           p: {
             component: Typography,
@@ -203,7 +201,6 @@ export default function SeeMoreResources() {
             props: {
               style: {
                 color: theme.palette.link.main,
-                wordBreak: 'break-all',
               },
             },
           },


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

The two long URLs were breaking so that they did not create additional right side white space, but they were creating an undesired effect on mobile screens. To fix this, instead we use a title with the underlying URL linked.

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/58a113a3-ad02-44c2-b54b-0e55c01c9d3c)

#### After
![image](https://github.com/user-attachments/assets/71eae002-92f4-4516-b2b8-2b11e051e98a)
