### PR TITLE
Mobile button hover

### DIFF
--- a/components/CustomButtons.tsx
+++ b/components/CustomButtons.tsx
@@ -51,6 +51,7 @@ export function CalculatorButton({
   return (
     <Button
       href={href}
+      className="calc-btn"
       variant="contained"
       size="small"
       data-cy={dataCy}

--- a/styles/global.css
+++ b/styles/global.css
@@ -11,3 +11,9 @@ html {
 main {
   height: 100%;
 }
+
+@media (hover: none) {
+  .calc-btn:hover {
+    background-color: initial; /* Reset the hover effect */
+  }
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -14,6 +14,8 @@ main {
 
 @media (hover: none) {
   .calc-btn:hover {
-    background-color: #00513C; /* Reset the hover effect */
+    color: #FFFEFC;
+    background-color: #00513C; 
+    box-shadow: none;
   }
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -14,6 +14,6 @@ main {
 
 @media (hover: none) {
   .calc-btn:hover {
-    background-color: initial; /* Reset the hover effect */
+    background-color: #00513C; /* Reset the hover effect */
   }
 }


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

When clicking through the calculator on mobile devices, the page transitions were happening very quickly, and a finger still on the button when the page changed, was triggering an active hover state over the button in the same position on the page as the button pressed on the last page. In order to fix this, I have disabled hover on touch devices.