### PR TITLE
Fix blake button issue

### DIFF
--- a/pages/calculator/[slug].tsx
+++ b/pages/calculator/[slug].tsx
@@ -61,6 +61,7 @@ export default function CalculatorSlugRoute({ page, calculatorConfig }: StaticCa
             xs: isPartOfHead ? 'normal' : 'space-between',
             sm: 'normal',
           },
+          marginBottom: { xs: '36px', sm: '0' },
         }}
         id="calculator-container-outer"
         tabIndex={-1}


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

On mobile screens the button on the Blake page was touching the footer. In order to avoid this situation I added a bottom margin of 36px to the outer calculator container on xs screens.

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/7299b10f-f659-45df-a8d2-273ccfc2e335)

#### After
![image](https://github.com/user-attachments/assets/9c4f3748-80b3-44d4-b1b7-d1cea4c681e4)
