### PR TITLE
add facebook and linkedin share buttons to footer

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -11,8 +11,56 @@ import {
   Typography,
   useMediaQuery,
 } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import { useTheme } from '@mui/material/styles';
 import React, { useState } from 'react';
+
+function SocialMediaShare() {
+  const websiteURL = 'https://clearviction.org';
+
+  const shareOnFacebook = () => {
+    const facebookShareURL = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
+      websiteURL,
+    )}`;
+    window.open(facebookShareURL, '_blank', 'noopener,noreferrer');
+  };
+
+  const shareOnLinkedIn = () => {
+    const linkedInShareURL = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+      websiteURL,
+    )}`;
+    window.open(linkedInShareURL, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <Box sx={{ padding: '20px', display: 'flex', gap: '28px' }}>
+      <IconButton
+        aria-label="LinkedIn share"
+        style={{ padding: '0' }}
+        onClick={shareOnLinkedIn}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="38" height="38" viewBox="0,0,256,256">
+          <g fill="none" fillRule="nonzero" stroke="none" strokeWidth="1" strokeLinecap="butt" strokeLinejoin="miter" strokeMiterlimit="10" strokeDasharray="" strokeDashoffset="0" fontFamily="none" fontWeight="none" fontSize="none" textAnchor="none">
+            <g transform="scale(5.33333,5.33333)">
+              <path d="M42,37c0,2.762 -2.238,5 -5,5h-26c-2.761,0 -5,-2.238 -5,-5v-26c0,-2.762 2.239,-5 5,-5h26c2.762,0 5,2.238 5,5z" fill="#0077b5" />
+              <path d="M12,19h5v17h-5zM14.485,17h-0.028c-1.492,0 -2.457,-1.112 -2.457,-2.501c0,-1.419 0.995,-2.499 2.514,-2.499c1.521,0 2.458,1.08 2.486,2.499c0,1.388 -0.965,2.501 -2.515,2.501zM36,36h-5v-9.099c0,-2.198 -1.225,-3.698 -3.192,-3.698c-1.501,0 -2.313,1.012 -2.707,1.99c-0.144,0.35 -0.101,1.318 -0.101,1.807v9h-5v-17h5v2.616c0.721,-1.116 1.85,-2.616 4.738,-2.616c3.578,0 6.261,2.25 6.261,7.274l0.001,9.726z" fill="#ffffff" />
+            </g>
+          </g>
+        </svg>
+      </IconButton>
+      <IconButton
+        aria-label="Facebook share"
+        style={{ padding: '0' }}
+        onClick={shareOnFacebook}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="38" height="38" viewBox="0 0 48 48">
+          <path fill="#3F51B5" d="M42,37c0,2.762-2.238,5-5,5H11c-2.761,0-5-2.238-5-5V11c0-2.762,2.239-5,5-5h26c2.762,0,5,2.238,5,5V37z" />
+          <path fill="#FFF" d="M34.368,25H31v13h-5V25h-3v-4h3v-2.41c0.002-3.508,1.459-5.59,5.592-5.59H35v4h-2.287C31.104,17,31,17.6,31,18.723V21h4L34.368,25z" />
+        </svg>
+      </IconButton>
+    </Box>
+  );
+}
 
 function LegalDisclaimerDialog({ openLegalDisclaimer, setOpenLegalDisclaimer }: { openLegalDisclaimer: boolean, setOpenLegalDisclaimer: React.Dispatch<React.SetStateAction<boolean>> }) {
   return (
@@ -187,6 +235,7 @@ function Footer({ isCalc }: FooterProps) {
                   PRIVACY NOTICE
                 </Button>
               </Typography>
+              <SocialMediaShare />
             </Stack>
           </Box>
         </Stack>
@@ -254,6 +303,7 @@ function Footer({ isCalc }: FooterProps) {
                   PRIVACY NOTICE
                 </Button>
               </Typography>
+              <SocialMediaShare />
             </Stack>
           </Box>
         </Stack>


### PR DESCRIPTION
### Type of change

- [x] Design change

### Description

Adds LinkedIn and Facebook social media share buttons using SVG icons. Clicking the button links to the social media page with the share already pre-populated with `clearviction.org` which will include the opengraph metadata.