### PR TITLE
remove set width from legal resources text block

### DIFF
--- a/pages/get-started/file-with-the-court.tsx
+++ b/pages/get-started/file-with-the-court.tsx
@@ -138,7 +138,6 @@ export default function FileWithTheCourt() {
         <Typography
           variant="body2"
           sx={{
-            width: '312px',
             marginBottom: '24px',
           }}
         >


### PR DESCRIPTION
### Type of change

- [x] Design change

### Description

Removes the set width on the text block that was causing it to render at `312px` instead of the full width of the outer container.

### Overall PR Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings in the console
- [x] There are no new linting errors/problems in my code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have filled this PR out fully, and cleaned up any extraneous items so that it is clear and easy to understand